### PR TITLE
[FEAT] JPA Auditing 설정 및 BaseEntity 추가

### DIFF
--- a/src/main/java/com/deare/backend/BackendApplication.java
+++ b/src/main/java/com/deare/backend/BackendApplication.java
@@ -2,15 +2,17 @@ package com.deare.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BackendApplication {
 
-	public static void main(String[] args) {
+    public static void main(String[] args) {
         // ▼▼▼ 이 줄을 추가해서 실행 창(Console) 로그를 확인해 주세요 ▼▼▼
         System.out.println(">>> CHECK DB_URL: " + System.getenv("DB_URL"));
 
         SpringApplication.run(BackendApplication.class, args);
-	}
+    }
 
 }

--- a/src/main/java/com/deare/backend/global/common/entity/BaseEntity.java
+++ b/src/main/java/com/deare/backend/global/common/entity/BaseEntity.java
@@ -1,0 +1,31 @@
+package com.deare.backend.global.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column
+    private LocalDateTime deletedAt;
+
+    @Column(nullable = false)
+    private Boolean isDeleted = false;
+}


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 요약 -->

- 엔티티의 생성일/수정일을 자동으로 관리하기 위해 JPA Auditing을 설정했습니다.
- BaseEntity를 추가하여 공통 엔티티 기반을 마련했습니다.
---

## 🔗 관련 이슈
<!-- 관련 이슈 번호 -->

- Closes #11 

---

## 🛠 변경 사항
<!-- 핵심 변경 내용 -->

- @EnableJpaAuditing 추가
- 공통 엔티티 BaseEntity 생성
    - createdAt, updatedAt, deletedAt, isDeleted 필드 포함
    - 이후 모든 엔티티에서 상속하여 사용 가능

---

## ⚠️ 리뷰 시 참고 사항
<!-- 리뷰어가 봐줬으면 하는 부분 -->

- 임시로 기존 users 엔티티에 extends하여 공통 컬럼들이 추가되는 것 확인할 수 있습니다!!
<img width="902" height="232" alt="image" src="https://github.com/user-attachments/assets/a1410dd3-bec3-4862-bca0-16249ca45bd1" />

---

## ✅ 체크리스트
- [x] 로컬에서 정상 실행됨
- [x] 로그 / 네이밍 정리
- [x] main / develop 직접 커밋 아님


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **감사 추적(Audit Trail)**: 모든 데이터의 생성 및 수정 시간이 자동으로 기록됩니다.
* **소프트 삭제 지원**: 데이터가 실제로 삭제되지 않고 삭제 표시되어 데이터 무결성을 보호합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->