### PR TITLE
[FEAT] 리포트 엔티티 구현

### DIFF
--- a/src/main/java/com/deare/backend/domain/report/entity/Report.java
+++ b/src/main/java/com/deare/backend/domain/report/entity/Report.java
@@ -1,0 +1,79 @@
+package com.deare.backend.domain.report.entity;
+
+import com.deare.backend.domain.user.entity.User;
+import com.deare.backend.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDate;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name="report",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name="uq_user_scope_month",
+                        columnNames = {"user_id", "scope", "report_year_month"}
+                )
+        }
+)
+public class Report extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="user_report_id")
+    private Long userReportId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name="scope", nullable = false)
+    private ReportScope scope;
+
+    @Column(name="report_year_month", nullable=false)
+    private LocalDate yearMonth;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name="recap_json", columnDefinition = "json")
+    private String recapJson;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name="top3_from_json", columnDefinition = "json")
+    private String top3FromJson;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name="top_phrase_json", columnDefinition = "json")
+    private String topPhraseJson;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name="emotion_dist_json", columnDefinition = "json")
+    private String emotionDistJson;
+
+    @Column(name="is_stale", nullable=false)
+    private Boolean isStale=false;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="user_id", nullable = false)
+    private User user;
+
+    public Report(User user, ReportScope scope, LocalDate yearMonth) {
+        this.user = user;
+        this.scope = scope;
+        this.yearMonth = yearMonth;
+        this.isStale = false;
+    }
+
+    public void markStale()
+    {
+        this.isStale=true;
+    }
+
+    public void markFresh()
+    {
+        this.isStale=false;
+    }
+}

--- a/src/main/java/com/deare/backend/domain/report/entity/ReportScope.java
+++ b/src/main/java/com/deare/backend/domain/report/entity/ReportScope.java
@@ -1,0 +1,5 @@
+package com.deare.backend.domain.report.entity;
+
+public enum ReportScope {
+    ALL_TIME, MONTH
+}


### PR DESCRIPTION
## 📌 PR 개요

리포트 엔티티 구현 
사용자, 통계 범위, 연월 기준으로 중복된 데이터가 생성되지 않도록 유니크 제약 조건 추가


## 🔗 관련 이슈

- Closes #36 


## 🛠 변경 사항
- 통계 범위(년/월) 구분을 위한 `ReportScope` ENUM 생성 
- user_id, report_year_month, scope를 기준으로 유니크 제약 조건 설정
- 프롬 TOP3, 감정 태그 통계, 문구 통계는 JSON 컬럼 기반으로 관리
- 리포트 재계산 여부를 관리할 is_stale 컬럼 추가
- is_stale 컬럼 갱신 가능한 `markStale`/`markFresh` 메서드 미리 정의
- User 엔티티와 1:1 관계

---

## ⚠️ 리뷰 시 참고 사항

- User 연관 관계가 제대로 매핑되어있는지 확인해주세요~!!
- user_id, scope, report_year_month 기준 유니크 제약 설정 잘 되어있는지 확인 부탁드립니다!!
- erd 관련 수정해야하는 부분도 있다면 알려주세요!!
---

## ✅ 체크리스트
- [x] 로컬에서 정상 실행됨
- [x] 로그 / 네이밍 정리
- [x] main / develop 직접 커밋 아님
