### PR TITLE
[FEAT] Folder 도메인 컨트롤러 추가

### DIFF
--- a/src/main/java/com/deare/backend/api/folder/FolderController.java
+++ b/src/main/java/com/deare/backend/api/folder/FolderController.java
@@ -1,0 +1,77 @@
+package com.deare.backend.api.folder;
+
+import com.deare.backend.domain.folder.dto.FolderCreateRequestDTO;
+import com.deare.backend.domain.folder.dto.FolderCreateResponseDTO;
+import com.deare.backend.domain.folder.dto.FolderListResponseDTO;
+import com.deare.backend.domain.folder.dto.FolderOrderRequestDTO;
+import com.deare.backend.domain.folder.dto.FolderUpdateRequestDTO;
+import com.deare.backend.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/folders")
+public class FolderController {
+
+    @GetMapping
+    @Operation(
+            summary = "폴더 목록 조회",
+            description = "폴더 목록을 리스트 형태로 조회합니다. 폴더 아이템은 사용자가 설정한 순서대로 반환됩니다."
+    )
+    public ApiResponse<FolderListResponseDTO> getFolderList() {
+        return ApiResponse.success(null);
+    }
+
+    @PostMapping
+    @Operation(
+            summary = "폴더 생성",
+            description = "1자 이상, 6자 이하로 폴더명을 설정해야 합니다."
+    )
+    public ApiResponse<FolderCreateResponseDTO> createFolder(@Valid @RequestBody FolderCreateRequestDTO reqDTO) {
+        return ApiResponse.success(null);
+    }
+
+    @DeleteMapping("/{folderId}")
+    @Operation(
+            summary = "폴더 삭제"
+    )
+    public ApiResponse<Void> deleteFolder(@PathVariable("folderId") Long folderId) {
+        return ApiResponse.success(null);
+    }
+
+    @PatchMapping("/orders")
+    @Operation(
+            summary = "폴더 순서 변경"
+    )
+    public ApiResponse<Void> updateOrders(@Valid @RequestBody FolderOrderRequestDTO reqDTO) {
+        return ApiResponse.success(null);
+    }
+
+    @PatchMapping("/{folderId}")
+    @Operation(
+            summary = "폴더 수정"
+    )
+    public ApiResponse<Void> updateFolder(
+            @PathVariable("folderId") Long folderId,
+            @Valid @RequestBody FolderUpdateRequestDTO reqDTO) {
+        return ApiResponse.success(null);
+    }
+
+
+    @PostMapping("/{folderId}/letters/{letterId}")
+    @Operation(
+            summary = "폴더에 편지 추가"
+    )
+    public ApiResponse<Void> addLetterToFolder(@PathVariable("folderId") Long folderId, @PathVariable("letterId") Long letterId) {
+        return ApiResponse.success(null);
+    }
+
+    @DeleteMapping("/{folderId}/letters/{letterId}")
+    @Operation(
+            summary = "폴더에서 편지 삭제"
+    )
+    public ApiResponse<Void> deleteLetterFromFolder(@PathVariable("folderId") Long folderId, @PathVariable("letterId") Long letterId) {
+        return ApiResponse.success(null);
+    }
+}

--- a/src/main/java/com/deare/backend/domain/folder/dto/FolderCreateRequestDTO.java
+++ b/src/main/java/com/deare/backend/domain/folder/dto/FolderCreateRequestDTO.java
@@ -1,0 +1,10 @@
+package com.deare.backend.domain.folder.dto;
+
+import jakarta.validation.constraints.Size;
+
+public record FolderCreateRequestDTO (
+        @Size(min = 1, max = 6)
+        String name,
+        Long imageId
+) {
+}

--- a/src/main/java/com/deare/backend/domain/folder/dto/FolderCreateResponseDTO.java
+++ b/src/main/java/com/deare/backend/domain/folder/dto/FolderCreateResponseDTO.java
@@ -1,0 +1,6 @@
+package com.deare.backend.domain.folder.dto;
+
+public record FolderCreateResponseDTO(
+        Long id,
+        String createdAt
+) {}

--- a/src/main/java/com/deare/backend/domain/folder/dto/FolderItemDTO.java
+++ b/src/main/java/com/deare/backend/domain/folder/dto/FolderItemDTO.java
@@ -1,0 +1,9 @@
+package com.deare.backend.domain.folder.dto;
+
+public record FolderItemDTO (
+        Long id,
+        String name,
+        String imageUrl,
+        int folderOrder
+){
+}

--- a/src/main/java/com/deare/backend/domain/folder/dto/FolderListResponseDTO.java
+++ b/src/main/java/com/deare/backend/domain/folder/dto/FolderListResponseDTO.java
@@ -1,0 +1,8 @@
+package com.deare.backend.domain.folder.dto;
+
+import java.util.List;
+
+public record FolderListResponseDTO(
+        List<FolderItemDTO> items
+) {
+}

--- a/src/main/java/com/deare/backend/domain/folder/dto/FolderOrderRequestDTO.java
+++ b/src/main/java/com/deare/backend/domain/folder/dto/FolderOrderRequestDTO.java
@@ -1,0 +1,13 @@
+package com.deare.backend.domain.folder.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record FolderOrderRequestDTO (
+        @Size(min = 1, max = 5)
+        List<@NotNull @Positive Long> foldersOrder
+) {
+}

--- a/src/main/java/com/deare/backend/domain/folder/dto/FolderUpdateRequestDTO.java
+++ b/src/main/java/com/deare/backend/domain/folder/dto/FolderUpdateRequestDTO.java
@@ -1,0 +1,15 @@
+package com.deare.backend.domain.folder.dto;
+
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record FolderUpdateRequestDTO (
+    @Size(min = 1, max = 6)
+    @Pattern(regexp = ".*\\S.*", message = "name은 공백만으로 구성될 수 없습니다.")
+    String name,
+    Long imageId
+){
+    public boolean hasAnyField() {
+        return name != null || imageId != null;
+    }
+}


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 요약 -->

- Folder 도메인에서 구현할 API를 컨트롤러 단에서 명세했습니다.

---

## 🔗 관련 이슈
<!-- 관련 이슈 번호 -->

- Closes #32

---

## 🛠 변경 사항
<!-- 핵심 변경 내용 -->

- 폴더 목록 조회
- 새 폴더 생성
- 폴더 순서 변경
- 폴더 수정
- 폴더에 편지 추가
- 폴더에서 편지 삭제

---

## ⚠️ 리뷰 시 참고 사항
<!-- 리뷰어가 봐줬으면 하는 부분 -->

- 검증 조건이 적절한지

---

## ✅ 체크리스트
- [x] 로컬에서 정상 실행됨
- [x] 로그 / 네이밍 정리
- [x] main / develop 직접 커밋 아님
