### PR TITLE
[FIX] springdoc-openapi 의존성 보안 취약점 대응

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ dependencies {
 
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+    implementation 'org.apache.commons:commons-lang3:3.18.0'
 
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 요약 -->
springdoc-opeapi 보안 취약점 경고 해결을 위한 작업 수행

## 🔗 관련 이슈
<!-- 관련 이슈 번호 -->
- Closes #67 


## 원인 분석
Mend.io 보안 스캐너에서 springdoc-openapi 사용에서 보안 취약점 경고(CVE-2025-48924: StackOverflowError 관련 위험) 발생해서 spirngdoc-openapi의 버전 문제라고 인식했으나
springdoc-openapi가 transitive로 포함하는 `commons-lang3` 라이브러리가 취약 버전 사용이었음을 발견함

## 🛠 변경 사항
<!-- 핵심 변경 내용 -->
- build.gradle의 의존성에 `implementation 'org.apache.commons:commons-lang3:3.18.0'` 추가


## ⚠️ 리뷰 시 참고 사항
<!-- 리뷰어가 봐줬으면 하는 부분 -->
springdoc-openapi의 버전을 교체하지는 않았고, commons-lang3 3.18.0을 직접 의존성으로 선언하여 이행적 의존성을 안전한 버전으로 override 함


## ✅ 체크리스트
- [x] 로컬에서 정상 실행됨
- [x] main / develop 직접 커밋 아님
