### PR TITLE
[FIX]: swagger에 security requirement 적용

### DIFF
--- a/src/main/java/com/deare/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/deare/backend/global/config/SwaggerConfig.java
@@ -19,7 +19,8 @@ public class SwaggerConfig {
                 .in(SecurityScheme.In.HEADER)
                 .name("Authorization");
 
-        SecurityRequirement securityRequirement = new SecurityRequirement();
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList("BearerAuth");
 
         return new OpenAPI()
                 .info(new Info().title("DearE Swagger API docs")


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 요약 -->
- Swagger SecurityRequirement에 BearerAuth 스킴을 명시적으로 적용
- Swagger 보안 스팩과 실제 인증 흐름을 일치하도록 설정 수정

---

## 🔗 관련 이슈
<!-- 관련 이슈 번호 -->

- Closes #69 

---

## 🛠 변경 사항
<!-- 핵심 변경 내용 -->

- Swagger API 별 자물쇠 ui 정상 노출됨
- SecurityRequirement에 JWT Bearer 인증 보안 스킴이 연결되어있지 않은 상태였어서, Authorize 속 accessToken Authorization 헤더로 정상 전달되도록 수정

---

## ⚠️ 리뷰 시 참고 사항
<!-- 리뷰어가 봐줬으면 하는 부분 -->

- Swagger ui 실행 시 각 api에도 자물쇠가 제대로 뜨는지 확인
    <img width="720" height="500" alt="image" src="https://github.com/user-attachments/assets/715db345-0e80-4b9c-9e45-3d31ca60584b" />

- Authorization의 accessToken이 api에 잘 전달되는지 확인

---

## ✅ 체크리스트
- [x] 로컬에서 정상 실행됨
- [x] 로그 / 네이밍 정리
- [x] main / develop 직접 커밋 아님
