### PR TITLE
[FIX] 폴더 삭제 시 삭제 안되는 문제 해결

### DIFF
--- a/src/main/java/com/deare/backend/api/folder/service/FolderServiceImpl.java
+++ b/src/main/java/com/deare/backend/api/folder/service/FolderServiceImpl.java
@@ -90,6 +90,7 @@ public class FolderServiceImpl implements FolderService {
 
         letterRepository.clearFolder(userId, folderId);
         folder.softDelete();
+        folderRepository.save(folder);
     }
 
     @Override


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 요약 -->
- FolderServiceImpl 내부의 deleteFolder 메서드에서 폴더 soft delete 이후 상태 변화 저장


## 🔗 관련 이슈
<!-- 관련 이슈 번호 -->
- Closes #121 


## 🛠 변경 사항
<!-- 핵심 변경 내용 -->
- FolderServiceImpl의 deleteFolder 메서드 softDelete 후 save() 메서드 호출해서 db 저장


## ⚠️ 리뷰 시 참고 사항
<!-- 리뷰어가 봐줬으면 하는 부분 -->
- folder의 is_deleted 상태가 제대로 변화하는지 확인
## ✅ 체크리스트
- [x] 로컬에서 정상 실행됨
- [x] 로그 / 네이밍 정리
- [x] main / develop 직접 커밋 아님
