### PR TITLE
[FIX] 폴더 이미지 삭제 처리 추가

### DIFF
--- a/src/main/java/com/deare/backend/api/folder/service/FolderServiceImpl.java
+++ b/src/main/java/com/deare/backend/api/folder/service/FolderServiceImpl.java
@@ -178,6 +178,8 @@ public class FolderServiceImpl implements FolderService {
                     .orElseThrow(() -> new GeneralException(FolderErrorCode.INVALID_REQUEST));
 
             folder.changeImage(image);
+        } else {
+            folder.changeImage(null);
         }
     }
 


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 요약 -->
requestDTO로 imageId가 null로 들어오면 Folder의 image null로 세팅

## 🔗 관련 이슈
<!-- 관련 이슈 번호 -->

- Closes #129 


## 🛠 변경 사항
<!-- 핵심 변경 내용 -->
- imageId 가 null일 때 처리 로직 추가

## ⚠️ 리뷰 시 참고 사항
<!-- 리뷰어가 봐줬으면 하는 부분 -->

## ✅ 체크리스트
- [ ] 로컬에서 정상 실행됨
- [ ] 로그 / 네이밍 정리
- [ ] main / develop 직접 커밋 아님
