### PR TITLE
[CHORE] letter, folder 도메인 dto 파일 패키지 분리

### DIFF
--- a/src/main/java/com/deare/backend/api/folder/controller/FolderController.java
+++ b/src/main/java/com/deare/backend/api/folder/controller/FolderController.java
@@ -1,11 +1,11 @@
 package com.deare.backend.api.folder.controller;
 
-import com.deare.backend.api.folder.dto.FolderCreateRequestDTO;
-import com.deare.backend.api.folder.dto.FolderCreateResponseDTO;
-import com.deare.backend.api.folder.dto.FolderListResponseDTO;
-import com.deare.backend.api.folder.dto.FolderOrderRequestDTO;
-import com.deare.backend.api.folder.dto.FolderUpdateRequestDTO;
-import com.deare.backend.api.folder.dto.FolderOrderResponseDTO;
+import com.deare.backend.api.folder.dto.request.FolderCreateRequestDTO;
+import com.deare.backend.api.folder.dto.response.FolderCreateResponseDTO;
+import com.deare.backend.api.folder.dto.response.FolderListResponseDTO;
+import com.deare.backend.api.folder.dto.request.FolderOrderRequestDTO;
+import com.deare.backend.api.folder.dto.request.FolderUpdateRequestDTO;
+import com.deare.backend.api.folder.dto.response.FolderOrderResponseDTO;
 import com.deare.backend.api.folder.service.FolderService;
 import com.deare.backend.global.auth.util.SecurityUtil;
 import com.deare.backend.global.common.response.ApiResponse;

--- a/src/main/java/com/deare/backend/api/folder/dto/FolderListResponseDTO.java
+++ b/src/main/java/com/deare/backend/api/folder/dto/FolderListResponseDTO.java
@@ -1,8 +1,0 @@
-package com.deare.backend.api.folder.dto;
-
-import java.util.List;
-
-public record FolderListResponseDTO(
-        List<FolderItemDTO> items
-) {
-}

--- a/src/main/java/com/deare/backend/api/folder/dto/request/FolderCreateRequestDTO.java
+++ b/src/main/java/com/deare/backend/api/folder/dto/request/FolderCreateRequestDTO.java
@@ -1,4 +1,4 @@
-package com.deare.backend.api.folder.dto;
+package com.deare.backend.api.folder.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/deare/backend/api/folder/dto/request/FolderOrderRequestDTO.java
+++ b/src/main/java/com/deare/backend/api/folder/dto/request/FolderOrderRequestDTO.java
@@ -1,4 +1,4 @@
-package com.deare.backend.api.folder.dto;
+package com.deare.backend.api.folder.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;

--- a/src/main/java/com/deare/backend/api/folder/dto/request/FolderUpdateRequestDTO.java
+++ b/src/main/java/com/deare/backend/api/folder/dto/request/FolderUpdateRequestDTO.java
@@ -1,4 +1,4 @@
-package com.deare.backend.api.folder.dto;
+package com.deare.backend.api.folder.dto.request;
 
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;

--- a/src/main/java/com/deare/backend/api/folder/dto/response/FolderCreateResponseDTO.java
+++ b/src/main/java/com/deare/backend/api/folder/dto/response/FolderCreateResponseDTO.java
@@ -1,4 +1,4 @@
-package com.deare.backend.api.folder.dto;
+package com.deare.backend.api.folder.dto.response;
 
 public record FolderCreateResponseDTO(
         Long id,

--- a/src/main/java/com/deare/backend/api/folder/dto/response/FolderListResponseDTO.java
+++ b/src/main/java/com/deare/backend/api/folder/dto/response/FolderListResponseDTO.java
@@ -1,0 +1,10 @@
+package com.deare.backend.api.folder.dto.response;
+
+import com.deare.backend.api.folder.dto.result.FolderItemDTO;
+
+import java.util.List;
+
+public record FolderListResponseDTO(
+        List<FolderItemDTO> items
+) {
+}

--- a/src/main/java/com/deare/backend/api/folder/dto/response/FolderOrderResponseDTO.java
+++ b/src/main/java/com/deare/backend/api/folder/dto/response/FolderOrderResponseDTO.java
@@ -1,4 +1,4 @@
-package com.deare.backend.api.folder.dto;
+package com.deare.backend.api.folder.dto.response;
 
 import java.util.List;
 

--- a/src/main/java/com/deare/backend/api/folder/dto/result/FolderItemDTO.java
+++ b/src/main/java/com/deare/backend/api/folder/dto/result/FolderItemDTO.java
@@ -1,4 +1,4 @@
-package com.deare.backend.api.folder.dto;
+package com.deare.backend.api.folder.dto.result;
 
 public record FolderItemDTO (
         Long id,

--- a/src/main/java/com/deare/backend/api/folder/service/FolderService.java
+++ b/src/main/java/com/deare/backend/api/folder/service/FolderService.java
@@ -1,11 +1,11 @@
 package com.deare.backend.api.folder.service;
 
-import com.deare.backend.api.folder.dto.FolderCreateRequestDTO;
-import com.deare.backend.api.folder.dto.FolderCreateResponseDTO;
-import com.deare.backend.api.folder.dto.FolderListResponseDTO;
-import com.deare.backend.api.folder.dto.FolderOrderResponseDTO;
-import com.deare.backend.api.folder.dto.FolderOrderRequestDTO;
-import com.deare.backend.api.folder.dto.FolderUpdateRequestDTO;
+import com.deare.backend.api.folder.dto.request.FolderCreateRequestDTO;
+import com.deare.backend.api.folder.dto.response.FolderCreateResponseDTO;
+import com.deare.backend.api.folder.dto.response.FolderListResponseDTO;
+import com.deare.backend.api.folder.dto.response.FolderOrderResponseDTO;
+import com.deare.backend.api.folder.dto.request.FolderOrderRequestDTO;
+import com.deare.backend.api.folder.dto.request.FolderUpdateRequestDTO;
 
 public interface FolderService {
 

--- a/src/main/java/com/deare/backend/api/folder/service/FolderServiceImpl.java
+++ b/src/main/java/com/deare/backend/api/folder/service/FolderServiceImpl.java
@@ -1,6 +1,12 @@
 package com.deare.backend.api.folder.service;
 
-import com.deare.backend.api.folder.dto.*;
+import com.deare.backend.api.folder.dto.request.FolderCreateRequestDTO;
+import com.deare.backend.api.folder.dto.request.FolderOrderRequestDTO;
+import com.deare.backend.api.folder.dto.request.FolderUpdateRequestDTO;
+import com.deare.backend.api.folder.dto.response.FolderCreateResponseDTO;
+import com.deare.backend.api.folder.dto.response.FolderListResponseDTO;
+import com.deare.backend.api.folder.dto.response.FolderOrderResponseDTO;
+import com.deare.backend.api.folder.dto.result.FolderItemDTO;
 import com.deare.backend.domain.folder.entity.Folder;
 import com.deare.backend.domain.folder.exception.FolderErrorCode;
 import com.deare.backend.domain.folder.repository.FolderRepository;

--- a/src/main/java/com/deare/backend/api/letter/controller/LetterController.java
+++ b/src/main/java/com/deare/backend/api/letter/controller/LetterController.java
@@ -1,6 +1,10 @@
 package com.deare.backend.api.letter.controller;
 
-import com.deare.backend.api.letter.dto.*;
+import com.deare.backend.api.letter.dto.request.LetterCreateRequestDTO;
+import com.deare.backend.api.letter.dto.request.LetterPinRequestDTO;
+import com.deare.backend.api.letter.dto.request.LetterReplyUpsertRequestDTO;
+import com.deare.backend.api.letter.dto.request.LetterUpdateRequestDTO;
+import com.deare.backend.api.letter.dto.response.*;
 import com.deare.backend.api.letter.service.LetterService;
 import com.deare.backend.api.letter.service.RandomLetterService;
 import com.deare.backend.global.auth.util.SecurityUtil;

--- a/src/main/java/com/deare/backend/api/letter/dto/request/LetterCreateRequestDTO.java
+++ b/src/main/java/com/deare/backend/api/letter/dto/request/LetterCreateRequestDTO.java
@@ -1,10 +1,8 @@
-package com.deare.backend.api.letter.dto;
+package com.deare.backend.api.letter.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 
 import java.time.LocalDate;
 import java.util.List;

--- a/src/main/java/com/deare/backend/api/letter/dto/request/LetterPinRequestDTO.java
+++ b/src/main/java/com/deare/backend/api/letter/dto/request/LetterPinRequestDTO.java
@@ -1,4 +1,4 @@
-package com.deare.backend.api.letter.dto;
+package com.deare.backend.api.letter.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 

--- a/src/main/java/com/deare/backend/api/letter/dto/request/LetterReplyUpsertRequestDTO.java
+++ b/src/main/java/com/deare/backend/api/letter/dto/request/LetterReplyUpsertRequestDTO.java
@@ -1,4 +1,4 @@
-package com.deare.backend.api.letter.dto;
+package com.deare.backend.api.letter.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;

--- a/src/main/java/com/deare/backend/api/letter/dto/request/LetterUpdateRequestDTO.java
+++ b/src/main/java/com/deare/backend/api/letter/dto/request/LetterUpdateRequestDTO.java
@@ -1,4 +1,4 @@
-package com.deare.backend.api.letter.dto;
+package com.deare.backend.api.letter.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSetter;

--- a/src/main/java/com/deare/backend/api/letter/dto/response/LetterCreateResponseDTO.java
+++ b/src/main/java/com/deare/backend/api/letter/dto/response/LetterCreateResponseDTO.java
@@ -1,4 +1,4 @@
-package com.deare.backend.api.letter.dto;
+package com.deare.backend.api.letter.dto.response;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/deare/backend/api/letter/dto/response/LetterDetailResponseDTO.java
+++ b/src/main/java/com/deare/backend/api/letter/dto/response/LetterDetailResponseDTO.java
@@ -1,4 +1,8 @@
-package com.deare.backend.api.letter.dto;
+package com.deare.backend.api.letter.dto.response;
+
+import com.deare.backend.api.letter.dto.result.EmotionTagDTO;
+import com.deare.backend.api.letter.dto.result.LetterFolderDTO;
+import com.deare.backend.api.letter.dto.result.LetterFromDTO;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/com/deare/backend/api/letter/dto/response/LetterLikeResponseDTO.java
+++ b/src/main/java/com/deare/backend/api/letter/dto/response/LetterLikeResponseDTO.java
@@ -1,4 +1,4 @@
-package com.deare.backend.api.letter.dto;
+package com.deare.backend.api.letter.dto.response;
 
 public record LetterLikeResponseDTO(
         boolean liked

--- a/src/main/java/com/deare/backend/api/letter/dto/response/LetterListResponseDTO.java
+++ b/src/main/java/com/deare/backend/api/letter/dto/response/LetterListResponseDTO.java
@@ -1,4 +1,6 @@
-package com.deare.backend.api.letter.dto;
+package com.deare.backend.api.letter.dto.response;
+
+import com.deare.backend.api.letter.dto.result.LetterItemDTO;
 
 import java.util.List;
 

--- a/src/main/java/com/deare/backend/api/letter/dto/response/LetterPinResponseDTO.java
+++ b/src/main/java/com/deare/backend/api/letter/dto/response/LetterPinResponseDTO.java
@@ -1,4 +1,4 @@
-package com.deare.backend.api.letter.dto;
+package com.deare.backend.api.letter.dto.response;
 
 public record LetterPinResponseDTO(
         Boolean pinned

--- a/src/main/java/com/deare/backend/api/letter/dto/response/RandomLetterResponseDTO.java
+++ b/src/main/java/com/deare/backend/api/letter/dto/response/RandomLetterResponseDTO.java
@@ -1,4 +1,4 @@
-package com.deare.backend.api.letter.dto;
+package com.deare.backend.api.letter.dto.response;
 
 public record RandomLetterResponseDTO(
         boolean hasLetter,

--- a/src/main/java/com/deare/backend/api/letter/dto/result/EmotionCategoryDTO.java
+++ b/src/main/java/com/deare/backend/api/letter/dto/result/EmotionCategoryDTO.java
@@ -1,4 +1,4 @@
-package com.deare.backend.api.letter.dto;
+package com.deare.backend.api.letter.dto.result;
 
 public record EmotionCategoryDTO(
         Long categoryId,

--- a/src/main/java/com/deare/backend/api/letter/dto/result/EmotionTagDTO.java
+++ b/src/main/java/com/deare/backend/api/letter/dto/result/EmotionTagDTO.java
@@ -1,4 +1,4 @@
-package com.deare.backend.api.letter.dto;
+package com.deare.backend.api.letter.dto.result;
 
 public record EmotionTagDTO(
         Long emotionId,

--- a/src/main/java/com/deare/backend/api/letter/dto/result/LetterFolderDTO.java
+++ b/src/main/java/com/deare/backend/api/letter/dto/result/LetterFolderDTO.java
@@ -1,4 +1,4 @@
-package com.deare.backend.api.letter.dto;
+package com.deare.backend.api.letter.dto.result;
 
 public record LetterFolderDTO(
         Long folderId,

--- a/src/main/java/com/deare/backend/api/letter/dto/result/LetterFromDTO.java
+++ b/src/main/java/com/deare/backend/api/letter/dto/result/LetterFromDTO.java
@@ -1,4 +1,4 @@
-package com.deare.backend.api.letter.dto;
+package com.deare.backend.api.letter.dto.result;
 
 public record LetterFromDTO(
         Long fromId,

--- a/src/main/java/com/deare/backend/api/letter/dto/result/LetterItemDTO.java
+++ b/src/main/java/com/deare/backend/api/letter/dto/result/LetterItemDTO.java
@@ -1,4 +1,4 @@
-package com.deare.backend.api.letter.dto;
+package com.deare.backend.api.letter.dto.result;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/com/deare/backend/api/letter/service/LetterService.java
+++ b/src/main/java/com/deare/backend/api/letter/service/LetterService.java
@@ -1,6 +1,10 @@
 package com.deare.backend.api.letter.service;
 
-import com.deare.backend.api.letter.dto.*;
+import com.deare.backend.api.letter.dto.request.LetterCreateRequestDTO;
+import com.deare.backend.api.letter.dto.request.LetterPinRequestDTO;
+import com.deare.backend.api.letter.dto.request.LetterReplyUpsertRequestDTO;
+import com.deare.backend.api.letter.dto.request.LetterUpdateRequestDTO;
+import com.deare.backend.api.letter.dto.response.*;
 import org.springframework.data.domain.Pageable;
 
 public interface LetterService {

--- a/src/main/java/com/deare/backend/api/letter/service/LetterServiceImpl.java
+++ b/src/main/java/com/deare/backend/api/letter/service/LetterServiceImpl.java
@@ -3,7 +3,12 @@ package com.deare.backend.api.letter.service;
 import com.deare.backend.api.analyze.dto.response.EmotionResponseDTO;
 import com.deare.backend.api.analyze.dto.response.ReAnalyzeResponseDTO;
 import com.deare.backend.api.analyze.service.LetterAnalyzeService;
-import com.deare.backend.api.letter.dto.*;
+import com.deare.backend.api.letter.dto.request.LetterCreateRequestDTO;
+import com.deare.backend.api.letter.dto.request.LetterPinRequestDTO;
+import com.deare.backend.api.letter.dto.request.LetterReplyUpsertRequestDTO;
+import com.deare.backend.api.letter.dto.request.LetterUpdateRequestDTO;
+import com.deare.backend.api.letter.dto.response.*;
+import com.deare.backend.api.letter.dto.result.*;
 import com.deare.backend.api.letter.util.ExcerptUtil;
 import com.deare.backend.domain.emotion.entity.Emotion;
 import com.deare.backend.domain.emotion.entity.LetterEmotion;
@@ -34,10 +39,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.time.LocalDate;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service

--- a/src/main/java/com/deare/backend/api/letter/service/RandomLetterService.java
+++ b/src/main/java/com/deare/backend/api/letter/service/RandomLetterService.java
@@ -1,7 +1,7 @@
 package com.deare.backend.api.letter.service;
 
 import com.deare.backend.api.letter.cache.RandomLetterCacheValue;
-import com.deare.backend.api.letter.dto.RandomLetterResponseDTO;
+import com.deare.backend.api.letter.dto.response.RandomLetterResponseDTO;
 import com.deare.backend.domain.letter.exception.LetterErrorCode;
 import com.deare.backend.domain.letter.entity.Letter;
 import com.deare.backend.domain.letter.repository.LetterRepository;

--- a/src/main/java/com/deare/backend/domain/letter/repository/query/LetterEmotionQueryRepository.java
+++ b/src/main/java/com/deare/backend/domain/letter/repository/query/LetterEmotionQueryRepository.java
@@ -1,6 +1,5 @@
 package com.deare.backend.domain.letter.repository.query;
 
-import com.deare.backend.api.letter.dto.EmotionTagDTO;
 import com.deare.backend.domain.letter.repository.query.dto.EmotionTagProjection;
 
 import java.util.List;


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 요약 -->

letter, folder 도메인 dto 파일들의 패키지를 request, response, result로 이동했습니다!

---

## 🔗 관련 이슈
<!-- 관련 이슈 번호 -->

- Closes #108

---

## 🛠 변경 사항
<!-- 핵심 변경 내용 -->

- XXXRequestDTO -> request 패키지로 이동
- XXXResponseDTO -> response 패키지로 이동
- XXXResultDTO -> result 패키지로 이동

---

## ⚠️ 리뷰 시 참고 사항
<!-- 리뷰어가 봐줬으면 하는 부분 -->

잘못 이동한 게 없는지

---

## ✅ 체크리스트
- [X] 로컬에서 정상 실행됨
- [X] 로그 / 네이밍 정리
- [X] main / develop 직접 커밋 아님
