### PR TITLE
[FIX] 프로필 조회 응답에 이메일/소셜 정보 추가

### DIFF
--- a/src/main/java/com/deare/backend/api/user/dto/response/ProfileResponseDTO.java
+++ b/src/main/java/com/deare/backend/api/user/dto/response/ProfileResponseDTO.java
@@ -1,12 +1,15 @@
 package com.deare.backend.api.user.dto.response;
 
 import com.deare.backend.domain.setting.entity.enums.MembershipPlan;
+import com.deare.backend.domain.user.entity.enums.Provider;
 
 public record ProfileResponseDTO(
         Long userId,
         String nickname,
         String intro,
         String profileImageUrl,
-        MembershipPlan membershipPlan
+        MembershipPlan membershipPlan,
+        String email,
+        Provider provider
 ) {
 }

--- a/src/main/java/com/deare/backend/api/user/service/UserServiceImpl.java
+++ b/src/main/java/com/deare/backend/api/user/service/UserServiceImpl.java
@@ -84,7 +84,9 @@ public class UserServiceImpl implements UserService {
                 user.getNickname(),
                 user.getIntro(),
                 user.getImage() != null ? user.getImage().getUrl() : null,
-                plan
+                plan,
+                user.getEmail(),
+                user.getProvider()
         );
     }
 


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 요약 -->

- 프로필 조회 API 응답에 누락된 소셜 연동 정보(이메일, provider)를 추가합니다.

---

## 🔗 관련 이슈
<!-- 관련 이슈 번호 -->

- Closes #152 

---

## 🛠 변경 사항
<!-- 핵심 변경 내용 -->

- ProfileResponseDTO에 email, provider 필드 추가
- UserServiceImpl 프로필 조회 응답 매핑(toProfileResponse) 수정

---

## ⚠️ 리뷰 시 참고 사항
<!-- 리뷰어가 봐줬으면 하는 부분 -->

X

---

## ✅ 체크리스트
- [x] 로컬에서 정상 실행됨
- [x] 로그 / 네이밍 정리
- [x] main / develop 직접 커밋 아님
