### PR TITLE
[FIX] 편지 고정 해제 후 재고정 상태 반영

### DIFF
--- a/src/main/java/com/deare/backend/api/letter/service/RandomLetterService.java
+++ b/src/main/java/com/deare/backend/api/letter/service/RandomLetterService.java
@@ -52,6 +52,10 @@ public class RandomLetterService {
                 if (pinnedOpt.isEmpty()) {
                     redisTemplate.delete(graceKey);
 
+                } else if (Boolean.TRUE.equals(pinnedOpt.get())) {
+                    // 유예 중이던 편지가 다시 고정된 경우
+                    redisTemplate.delete(graceKey);
+
                 } else {
                     // 오늘은 기존 고정 편지를 그대로 내려줌
                     return toResponseDTO(true, today, v.letterId(), v.randomPhrase(), false);


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 요약 -->

- 랜덤 편지 조회 시 편지 고정 -> 고정 해제 -> 다시 고정 상태를 반영합니다.

---

## 🔗 관련 이슈
<!-- 관련 이슈 번호 -->

- Closes #171 

---

## 🛠 변경 사항
<!-- 핵심 변경 내용 -->

- 편지 고정 해제 시 유예 중이던 캐시를 재고정 시 삭제 

---

## ⚠️ 리뷰 시 참고 사항
<!-- 리뷰어가 봐줬으면 하는 부분 -->

X

---

## ✅ 체크리스트
- [x] 로컬에서 정상 실행됨
- [x] 로그 / 네이밍 정리
- [x] main / develop 직접 커밋 아님
