### PR TITLE
[FIX] 폴더 수정 로직 변경

### DIFF
--- a/src/main/java/com/deare/backend/api/folder/dto/request/FolderImageAction.java
+++ b/src/main/java/com/deare/backend/api/folder/dto/request/FolderImageAction.java
@@ -1,0 +1,7 @@
+package com.deare.backend.api.folder.dto.request;
+
+public enum FolderImageAction {
+    KEEP,
+    CHANGE,
+    DELETE
+}

--- a/src/main/java/com/deare/backend/api/folder/dto/request/FolderUpdateRequestDTO.java
+++ b/src/main/java/com/deare/backend/api/folder/dto/request/FolderUpdateRequestDTO.java
@@ -7,9 +7,22 @@ public record FolderUpdateRequestDTO (
     @Size(min = 1, max = 6)
     @Pattern(regexp = ".*\\S.*", message = "name은 공백만으로 구성될 수 없습니다.")
     String name,
-    Long imageId
+    Long imageId,
+    FolderImageAction imageAction
 ){
     public boolean hasAnyField() {
-        return name != null || imageId != null;
+        return name != null || imageAction != null;
+    }
+
+    public boolean hasInvalidImageRequest() {
+        if (imageAction == null || imageAction == FolderImageAction.KEEP) {
+            return imageId != null;
+        }
+
+        if (imageAction == FolderImageAction.CHANGE) {
+            return imageId == null;
+        }
+
+        return imageId != null;
     }
 }

--- a/src/main/java/com/deare/backend/api/folder/service/FolderServiceImpl.java
+++ b/src/main/java/com/deare/backend/api/folder/service/FolderServiceImpl.java
@@ -11,6 +11,7 @@ import com.deare.backend.domain.folder.entity.Folder;
 import com.deare.backend.domain.folder.exception.FolderErrorCode;
 import com.deare.backend.domain.folder.repository.FolderRepository;
 import com.deare.backend.domain.image.entity.Image;
+import com.deare.backend.domain.image.exception.ImageErrorCode;
 import com.deare.backend.domain.image.repository.ImageRepository;
 import com.deare.backend.domain.letter.entity.Letter;
 import com.deare.backend.domain.letter.exception.LetterErrorCode;
@@ -58,7 +59,7 @@ public class FolderServiceImpl implements FolderService {
     @Transactional
     public FolderCreateResponseDTO createFolder(Long userId, FolderCreateRequestDTO req) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(FolderErrorCode.FOLDER_50001));
+                .orElseThrow(() -> new GeneralException(FolderErrorCode.FOLDER_SERVER_ERROR));
 
         long count = folderRepository.countByUser_IdAndIsDeletedFalse(userId);
         if (count >= MAX_FOLDERS) {
@@ -168,7 +169,9 @@ public class FolderServiceImpl implements FolderService {
     @Override
     @Transactional
     public void updateFolder(Long userId, Long folderId, FolderUpdateRequestDTO reqDTO) {
-        if (reqDTO == null || !reqDTO.hasAnyField()) {
+        if (reqDTO == null
+                || !reqDTO.hasAnyField()
+                || reqDTO.hasInvalidImageRequest()) {
             throw new GeneralException(FolderErrorCode.INVALID_REQUEST);
         }
 
@@ -179,13 +182,22 @@ public class FolderServiceImpl implements FolderService {
             folder.rename(reqDTO.name().trim());
         }
 
-        if (reqDTO.imageId() != null) {
-            Image image = imageRepository.findById(reqDTO.imageId())
-                    .orElseThrow(() -> new GeneralException(FolderErrorCode.INVALID_REQUEST));
+        if (reqDTO.imageAction() == null) {
+            return;
+        }
 
-            folder.changeImage(image);
-        }else{
-            folder.changeImage(null);
+        switch (reqDTO.imageAction()) {
+            case KEEP -> {
+            }
+
+            case CHANGE -> {
+                Image image = imageRepository.findById(reqDTO.imageId())
+                        .orElseThrow(() -> new GeneralException(ImageErrorCode.IMAGE_NOT_FOUND));
+
+                folder.changeImage(image);
+            }
+
+            case DELETE -> folder.changeImage(null);
         }
     }
 

--- a/src/main/java/com/deare/backend/api/letter/service/LetterServiceImpl.java
+++ b/src/main/java/com/deare/backend/api/letter/service/LetterServiceImpl.java
@@ -183,7 +183,7 @@ public class LetterServiceImpl implements LetterService {
 
             List<Image> images = imageRepository.findAllById(imageIds);
             if (images.size() != imageIds.size()) {
-                throw new GeneralException(ImageErrorCode.IMAGE_40401);
+                throw new GeneralException(ImageErrorCode.IMAGE_NOT_FOUND);
             }
 
             Map<Long, Image> imageMap = images.stream()

--- a/src/main/java/com/deare/backend/domain/folder/exception/FolderErrorCode.java
+++ b/src/main/java/com/deare/backend/domain/folder/exception/FolderErrorCode.java
@@ -55,7 +55,7 @@ public enum FolderErrorCode implements BaseErrorCode {
     ),
 
     // 추후 고도화 시 COMMON으로 빼는 것도 고려
-    FOLDER_50001(
+    FOLDER_SERVER_ERROR(
             HttpStatus.INTERNAL_SERVER_ERROR,
             "FOLDER_50001",
             "폴더 처리 중 서버 오류가 발생했습니다."

--- a/src/main/java/com/deare/backend/domain/image/exception/ImageErrorCode.java
+++ b/src/main/java/com/deare/backend/domain/image/exception/ImageErrorCode.java
@@ -11,7 +11,7 @@ public enum ImageErrorCode implements BaseErrorCode {
     IMAGE_40002(HttpStatus.BAD_REQUEST, "IMAGE_40002", "이미지 dir 값은 필수입니다."),
     IMAGE_40101(HttpStatus.UNAUTHORIZED, "IMAGE_40101", "로그인이 필요한 요청입니다."),
     IMAGE_40301(HttpStatus.FORBIDDEN, "IMAGE_40301", "해당 이미지에 접근할 권한이 없습니다."),
-    IMAGE_40401(HttpStatus.NOT_FOUND, "IMAGE_40401", "이미지를 찾을 수 없습니다."),
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE_40401", "이미지를 찾을 수 없습니다."),
     IMAGE_41301(HttpStatus.PAYLOAD_TOO_LARGE, "IMAGE_41301", "업로드 가능한 용량을 초과했습니다."),
     IMAGE_50001(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_50001", "이미지 업로드 중 서버 오류가 발생했습니다.");
 

--- a/src/main/java/com/deare/backend/domain/letter/entity/Letter.java
+++ b/src/main/java/com/deare/backend/domain/letter/entity/Letter.java
@@ -27,7 +27,7 @@ public class Letter extends BaseEntity {
     private Long id;
 
     @Lob
-    @Column(name="content", columnDefinition = "TEXT", nullable = false)
+    @Column(name="content", columnDefinition = "LONGTEXT", nullable = false)
     private String content;
 
     @Column(name="received_at")

--- a/src/main/java/com/deare/backend/domain/term/entity/Term.java
+++ b/src/main/java/com/deare/backend/domain/term/entity/Term.java
@@ -26,7 +26,7 @@ public class Term extends BaseEntity {
     private TermType type;
 
     @Lob
-    @Column(name = "content", nullable = false)
+    @Column(name = "content", columnDefinition = "LONGTEXT", nullable = false)
     private String content;
 
     @Column(name = "is_required", nullable = false)


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 요약 -->

- 폴더 수정 로직 변경

---

## 🔗 관련 이슈
<!-- 관련 이슈 번호 -->

- Closes #240

---

## 🛠 변경 사항
<!-- 핵심 변경 내용 -->

- 폴더명만 수정하더라도 폴더 이미지가 null로 변경되는 오류가 있었습니다.
- FolderImageAction이라는 ENUM 파일을 추가하여 폴더 수정 시 이미지 유지/변경/삭제를 명시적으로 나타내도록 했습니다.
- 로컬 테스트 시 Flyway 마이그레이션과 충돌이 나는 부분이 있어 Letter 엔티티와 Term 엔티티의 content를 LONGTEXT로 변경했습니다.

---

## ⚠️ 리뷰 시 참고 사항
<!-- 리뷰어가 봐줬으면 하는 부분 -->

- 적절한 설계와 구현인지

---

## ✅ 체크리스트
- [X] 로컬에서 정상 실행됨
- [X] 로그 / 네이밍 정리
- [X] main / develop 직접 커밋 아님


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 폴더 이미지 수정 시 유지, 변경, 삭제 작업을 선택할 수 있습니다.
  * 이미지 변경 요청에 대한 유효성 검사가 강화되었습니다.

* **버그 수정**
  * 존재하지 않는 이미지 처리 시 일관된 오류가 표시됩니다.
  * 폴더 생성 및 편지 작성 중 리소스를 찾지 못한 경우의 오류 처리가 개선되었습니다.

* **개선**
  * 편지와 용어에 더 긴 콘텐츠를 저장할 수 있도록 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->