### PR TITLE
[FEAT] 랜덤 편지 재추첨 로직 수정

### DIFF
--- a/src/main/java/com/deare/backend/api/letter/service/RandomLetterService.java
+++ b/src/main/java/com/deare/backend/api/letter/service/RandomLetterService.java
@@ -271,26 +271,54 @@ public class RandomLetterService {
         // 동시성 처리: 먼저 저장한 요청이 있으면 그 값을 사용
         Boolean ok = redisTemplate.opsForValue().setIfAbsent(key, json, ttl);
 
-        RandomLetterCacheValue finalValue = created;
         if (Boolean.FALSE.equals(ok)) {
             String latest = redisTemplate.opsForValue().get(key);
-            if (latest != null) {
-                RandomLetterCacheValue parsed = fromJson(latest);
-                if (parsed != null && parsed.letterId() != null) {
-                    finalValue = parsed;
-                }
+            RandomLetterCacheValue parsed =
+                    latest != null ? fromJson(latest) : null;
+
+            if (parsed == null) {
+                // 캐시가 삭제되거나 손상된 예외 상황에서는 현재 요청 결과 반환
+                return toResponseDTO(
+                        true,
+                        today,
+                        created.letterId(),
+                        created.randomPhrase(),
+                        false
+                );
             }
+
+            // 다른 요청이 당일 종료를 먼저 기록한 경우
+            if (parsed.letterId() == null) {
+                return toResponseDTO(
+                        false,
+                        today,
+                        null,
+                        null,
+                        false
+                );
+            }
+
+            boolean pinnedNow = letterRepository.findIsPinnedByUserIdAndLetterId(userId, parsed.letterId())
+                    .orElse(false);
+
+            return toResponseDTO(
+                    true,
+                    today,
+                    parsed.letterId(),
+                    parsed.randomPhrase(),
+                    pinnedNow
+            );
         }
 
         // pinned 상태는 DB의 최신값 사용
-        boolean pinnedNow = letterRepository.findIsPinnedByUserIdAndLetterId(userId, finalValue.letterId())
+        boolean pinnedNow = letterRepository.findIsPinnedByUserIdAndLetterId(userId, created.letterId())
                 .orElse(false);
 
         return toResponseDTO(
                 true,
                 today,
-                finalValue.letterId(),
-                finalValue.randomPhrase(),
+                created.letterId(),
+                created.randomPhrase(),
                 pinnedNow
         );
     }

--- a/src/main/java/com/deare/backend/api/letter/service/RandomLetterService.java
+++ b/src/main/java/com/deare/backend/api/letter/service/RandomLetterService.java
@@ -35,10 +35,14 @@ public class RandomLetterService {
     public RandomLetterResponseDTO getTodayRandomLetter(long userId) {
         LocalDate today = LocalDate.now(ZONE);
 
+        // 오늘 하루의 랜덤 편지 최종 결정 캐시 키
+        String key = cacheKey(userId, today);
+
         // 오늘 날짜 기준 고정 해제 유예 캐시 키
         String graceKey = unpinGraceKey(userId, today);
 
         String graceCached = redisTemplate.opsForValue().get(graceKey);
+
         if (graceCached != null) {
             RandomLetterCacheValue v = fromJson(graceCached);
 
@@ -48,9 +52,10 @@ public class RandomLetterService {
                 // DB에서 현재 고정 상태 확인
                 Optional<Boolean> pinnedOpt = letterRepository.findIsPinnedByUserIdAndLetterId(userId, v.letterId());
 
-                // DB에 해당 편지가 없거나 권한 불일치면 유예 캐시 삭제
+                // 유예 캐시가 가리키던 편지가 삭제된 경우
                 if (pinnedOpt.isEmpty()) {
                     redisTemplate.delete(graceKey);
+                    return lockOutForToday(key, today);
 
                 } else if (Boolean.TRUE.equals(pinnedOpt.get())) {
                     // 유예 중이던 편지가 다시 고정된 경우
@@ -58,9 +63,16 @@ public class RandomLetterService {
 
                 } else {
                     // 오늘은 기존 고정 편지를 그대로 내려줌
-                    return toResponseDTO(true, today, v.letterId(), v.randomPhrase(), false);
+                    return toResponseDTO(
+                            true,
+                            today,
+                            v.letterId(),
+                            v.randomPhrase(),
+                            false
+                    );
                 }
             } else {
+                // JSON 파싱 실패 또는 비정상 캐시는 삭제 후 정상 흐름 진행
                 redisTemplate.delete(graceKey);
             }
         }
@@ -88,7 +100,13 @@ public class RandomLetterService {
 
                 } else {
                     // 캐시가 정상이고 DB와 일치하면 그대로 반환
-                    return toResponseDTO(true, today, v.letterId(), v.randomPhrase(), true);
+                    return toResponseDTO(
+                            true,
+                            today,
+                            v.letterId(),
+                            v.randomPhrase(),
+                            true
+                    );
                 }
             }
 
@@ -98,12 +116,18 @@ public class RandomLetterService {
 
             redisTemplate.opsForValue().set(pinnedKey, toJson(createdPinned));
 
-            return toResponseDTO(true, today,
-                    createdPinned.letterId(), createdPinned.randomPhrase(), true);
+            return toResponseDTO(
+                    true,
+                    today,
+                    createdPinned.letterId(),
+                    createdPinned.randomPhrase(),
+                    true
+            );
         }
 
         // 현재 DB에는 고정 편지가 없는데 pinned 캐시는 남아 있는 경우 (고정 해제 직후)
         String pinnedKey = pinnedKey(userId);
+
         String pinnedCached = redisTemplate.opsForValue().get(pinnedKey);
 
         if (pinnedCached != null) {
@@ -125,43 +149,87 @@ public class RandomLetterService {
                     // pinned 캐시는 제거
                     redisTemplate.delete(pinnedKey);
 
-                    return toResponseDTO(true, today,
-                            v.letterId(), v.randomPhrase(), false);
+                    return toResponseDTO(
+                            true,
+                            today,
+                            v.letterId(),
+                            v.randomPhrase(),
+                            false
+                    );
                 }
             }
 
+            // pinned 캐시가 가리키던 편지가 삭제된 경우
             redisTemplate.delete(pinnedKey);
+            return lockOutForToday(key, today);
         }
-
-        // userId + 날짜 키
-        String key = cacheKey(userId, today);
 
         // 1) Redis HIT: 오늘 이미 랜덤 결과가 있으면 그걸 사용
         String cached = redisTemplate.opsForValue().get(key);
+
         if (cached != null) {
             RandomLetterCacheValue v = fromJson(cached);
 
-            // 캐시가 깨진 경우 -> 캐시 삭제 후 재생성
-            if (v == null || v.letterId() == null) {
+            // JSON 자체를 읽지 못한 경우 캐시 삭제 후 재생성
+            if (v == null) {
                 redisTemplate.delete(key);
                 return createAndCache(userId, today, key);
+            }
+
+            // 오늘은 더 이상 편지를 보여주지 않는 경우
+            if (v.letterId() == null) {
+                return toResponseDTO(
+                        false,
+                        today,
+                        null,
+                        null,
+                        false
+                );
             }
 
             Optional<Boolean> pinnedOpt = letterRepository.findIsPinnedByUserIdAndLetterId(userId, v.letterId());
 
+            // 오늘 추첨된 편지가 삭제된 경우 재추첨하지 않음
             if (pinnedOpt.isEmpty()) {
-                // 삭제/숨김/권한불일치 등 -> 캐시 삭제 후 재생성
-                redisTemplate.delete(key);
-                return createAndCache(userId, today, key);
+                return lockOutForToday(key, today);
             }
 
-            // pinned는 최신값
+            // pinned 상태는 DB의 최신값 사용
             boolean pinnedNow = pinnedOpt.orElse(false);
-            return toResponseDTO(true, today, v.letterId(), v.randomPhrase(), pinnedNow);
+
+            return toResponseDTO(
+                    true,
+                    today,
+                    v.letterId(),
+                    v.randomPhrase(),
+                    pinnedNow
+            );
         }
 
         // 2) Redis MISS: 오늘의 랜덤 편지 새로 생성
         return createAndCache(userId, today, key);
+    }
+
+    private RandomLetterResponseDTO lockOutForToday(
+            String key,
+            LocalDate today
+    ) {
+        RandomLetterCacheValue empty =
+                new RandomLetterCacheValue(null, null);
+
+        redisTemplate.opsForValue().set(
+                key,
+                toJson(empty),
+                ttlUntilNextMidnight()
+        );
+
+        return toResponseDTO(
+                false,
+                today,
+                null,
+                null,
+                false
+        );
     }
 
     private RandomLetterResponseDTO createAndCache(long userId, LocalDate today, String key) {
@@ -169,7 +237,13 @@ public class RandomLetterService {
 
         // 편지가 없으면 캐시 저장 없이 바로 응답
         if (count == 0) {
-            return toResponseDTO(false, today, null, null, false);
+            return toResponseDTO(
+                    false,
+                    today,
+                    null,
+                    null,
+                    false
+            );
         }
 
         // 0 ~ count-1 사이 랜덤 offset
@@ -201,11 +275,17 @@ public class RandomLetterService {
             }
         }
 
-        // pinned는 항상 최신 조회
+        // pinned 상태는 DB의 최신값 사용
         boolean pinnedNow = letterRepository.findIsPinnedByUserIdAndLetterId(userId, finalValue.letterId())
                 .orElse(false);
 
-        return toResponseDTO(true, today, finalValue.letterId(), finalValue.randomPhrase(), pinnedNow);
+        return toResponseDTO(
+                true,
+                today,
+                finalValue.letterId(),
+                finalValue.randomPhrase(),
+                pinnedNow
+        );
     }
 
     private String extractRandomPhrase(String content) {
@@ -214,9 +294,11 @@ public class RandomLetterService {
         String normalized = content.trim();
         if (normalized.isEmpty()) return null;
 
-        // 기본 문장 분리:
-        // 1) 문장부호(.!?)+공백 기준
-        // 2) 줄바꿈 기준
+        /*
+         * 기본 문장 분리:
+         * 1. 문장부호(.!?)+공백 기준
+         * 2. 줄바꿈 기준
+         */
         String[] raw = normalized.split("(?<=[.!?])\\s+|\\n+");
 
         // 너무 짧은 후보 제거
@@ -227,17 +309,17 @@ public class RandomLetterService {
         }
 
         // 후보가 하나도 없으면 전체 본문 일부를 잘라서 반환
-        if (candidates.isEmpty()) return ellipsis(normalized, MAX_PHRASE_CHARS);
+        if (candidates.isEmpty()) return ellipsis(normalized);
 
         // 후보 중 랜덤 선택
         String picked = candidates.get(ThreadLocalRandom.current().nextInt(candidates.size()));
-        return ellipsis(picked, MAX_PHRASE_CHARS);
+        return ellipsis(picked);
     }
 
-    private String ellipsis(String s, int maxChars) {
+    private String ellipsis(String s) {
         if (s == null) return null;
-        if (s.length() <= maxChars) return s;
-        return s.substring(0, Math.max(0, maxChars - 1)) + "…";
+        if (s.length() <= RandomLetterService.MAX_PHRASE_CHARS) return s;
+        return s.substring(0, Math.max(0, RandomLetterService.MAX_PHRASE_CHARS - 1)) + "…";
     }
 
     private RandomLetterResponseDTO toResponseDTO(

--- a/src/main/java/com/deare/backend/api/letter/service/RandomLetterService.java
+++ b/src/main/java/com/deare/backend/api/letter/service/RandomLetterService.java
@@ -133,20 +133,27 @@ public class RandomLetterService {
         if (pinnedCached != null) {
             RandomLetterCacheValue v = fromJson(pinnedCached);
 
-            if (v != null && v.letterId() != null) {
+            // JSON 파싱 실패 또는 비정상 캐시는 삭제 후 일반 흐름 계속
+            if (v == null || v.letterId() == null) {
+                redisTemplate.delete(pinnedKey);
 
+            } else {
                 Optional<Boolean> pinnedOpt =
-                        letterRepository.findIsPinnedByUserIdAndLetterId(userId, v.letterId());
+                        letterRepository.findIsPinnedByUserIdAndLetterId(
+                                userId,
+                                v.letterId()
+                        );
 
                 // DB에 편지가 여전히 존재하면 오늘 자정까지 유예로 유지
                 if (pinnedOpt.isPresent()) {
-
                     Duration ttl = ttlUntilNextMidnight();
 
-                    // 오늘 날짜 유예 캐시에 저장 (자정까지 유지)
-                    redisTemplate.opsForValue().set(graceKey, toJson(v), ttl);
+                    redisTemplate.opsForValue().set(
+                            graceKey,
+                            toJson(v),
+                            ttl
+                    );
 
-                    // pinned 캐시는 제거
                     redisTemplate.delete(pinnedKey);
 
                     return toResponseDTO(
@@ -157,11 +164,11 @@ public class RandomLetterService {
                             false
                     );
                 }
-            }
 
-            // pinned 캐시가 가리키던 편지가 삭제된 경우
-            redisTemplate.delete(pinnedKey);
-            return lockOutForToday(key, today);
+                // pinned 캐시가 가리키던 편지가 실제로 삭제된 경우
+                redisTemplate.delete(pinnedKey);
+                return lockOutForToday(key, today);
+            }
         }
 
         // 1) Redis HIT: 오늘 이미 랜덤 결과가 있으면 그걸 사용

--- a/src/test/java/com/deare/backend/api/letter/service/RandomLetterServiceTest.java
+++ b/src/test/java/com/deare/backend/api/letter/service/RandomLetterServiceTest.java
@@ -1,0 +1,255 @@
+package com.deare.backend.api.letter.service;
+
+import com.deare.backend.api.letter.dto.response.RandomLetterResponseDTO;
+import com.deare.backend.domain.letter.entity.Letter;
+import com.deare.backend.domain.letter.repository.LetterRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class RandomLetterServiceTest {
+
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+
+    private final Map<String, String> store = new ConcurrentHashMap<>();
+
+    private RedisTemplate<String, String> redisTemplate;
+    private ValueOperations<String, String> valueOperations;
+    private LetterRepository letterRepository;
+    private RandomLetterService service;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUp() {
+        store.clear();
+
+        redisTemplate = mock(RedisTemplate.class);
+        valueOperations = mock(ValueOperations.class);
+        letterRepository = mock(LetterRepository.class);
+
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        when(valueOperations.get(anyString()))
+                .thenAnswer(inv -> store.get((String) inv.getArgument(0)));
+
+        doAnswer(inv -> {
+            store.put(inv.getArgument(0), inv.getArgument(1));
+            return null;
+        }).when(valueOperations).set(anyString(), anyString());
+
+        doAnswer(inv -> {
+            store.put(inv.getArgument(0), inv.getArgument(1));
+            return null;
+        }).when(valueOperations).set(anyString(), anyString(), any(Duration.class));
+
+        when(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class)))
+                .thenAnswer(inv -> {
+                    String key = inv.getArgument(0);
+                    String value = inv.getArgument(1);
+                    if (store.containsKey(key)) return false;
+                    store.put(key, value);
+                    return true;
+                });
+
+        when(redisTemplate.delete(anyString()))
+                .thenAnswer(inv -> store.remove((String) inv.getArgument(0)) != null);
+
+        service = new RandomLetterService(redisTemplate, new ObjectMapper(), letterRepository);
+    }
+
+    private Letter mockLetter(long id, String content) {
+        Letter letter = mock(Letter.class);
+        when(letter.getId()).thenReturn(id);
+        when(letter.getContent()).thenReturn(content);
+        return letter;
+    }
+
+    private String pinnedKeyOf(long userId) {
+        return "letters:pinned:" + userId;
+    }
+
+    private String dateKeyOf(long userId) {
+        return "letters:random:" + userId + ":" + LocalDate.now(SEOUL);
+    }
+
+    @Test
+    @DisplayName("정상 추첨: 하루 안에서는 같은 편지를 반복 반환한다")
+    void normalDraw_isCachedForTheDay() {
+        long userId = 100L;
+        Letter letter = mockLetter(10L, "테스트용 편지 본문입니다. 오늘 하루도 힘내세요!");
+
+        when(letterRepository.findPinnedLetterByUser(userId)).thenReturn(Optional.empty());
+        when(letterRepository.countVisibleLettersByUser(userId)).thenReturn(2L);
+        when(letterRepository.findRandomLetterByUser(eq(userId), anyLong())).thenReturn(Optional.of(letter));
+        when(letterRepository.findIsPinnedByUserIdAndLetterId(userId, 10L)).thenReturn(Optional.of(false));
+
+        RandomLetterResponseDTO first = service.getTodayRandomLetter(userId);
+        assertThat(first.hasLetter()).isTrue();
+        assertThat(first.letterId()).isEqualTo(10L);
+        assertThat(first.randomPhrase()).isNotBlank();
+
+        RandomLetterResponseDTO second = service.getTodayRandomLetter(userId);
+        assertThat(second.letterId()).isEqualTo(10L);
+
+        verify(letterRepository, times(1)).findRandomLetterByUser(eq(userId), anyLong());
+    }
+
+    @Test
+    @DisplayName("A. 오늘 추첨된(비고정) 편지가 삭제되면 재추첨하지 않고 하루 종일 잠긴다")
+    void deletedDrawnLetter_locksForRestOfDay() {
+        long userId = 101L;
+        Letter letter = mockLetter(11L, "테스트용 편지 본문입니다. 오늘 하루도 힘내세요!");
+
+        when(letterRepository.findPinnedLetterByUser(userId)).thenReturn(Optional.empty());
+        when(letterRepository.countVisibleLettersByUser(userId)).thenReturn(1L);
+        when(letterRepository.findRandomLetterByUser(eq(userId), anyLong())).thenReturn(Optional.of(letter));
+        when(letterRepository.findIsPinnedByUserIdAndLetterId(userId, 11L)).thenReturn(Optional.of(false));
+
+        RandomLetterResponseDTO drawn = service.getTodayRandomLetter(userId);
+        assertThat(drawn.letterId()).isEqualTo(11L);
+
+        when(letterRepository.findIsPinnedByUserIdAndLetterId(userId, 11L)).thenReturn(Optional.empty());
+
+        RandomLetterResponseDTO afterDelete = service.getTodayRandomLetter(userId);
+        assertThat(afterDelete.hasLetter()).isFalse();
+        assertThat(afterDelete.letterId()).isNull();
+
+        RandomLetterResponseDTO stillLocked = service.getTodayRandomLetter(userId);
+        assertThat(stillLocked.hasLetter()).isFalse();
+
+        verify(letterRepository, times(1)).findRandomLetterByUser(eq(userId), anyLong());
+    }
+
+    @Test
+    @DisplayName("B. 고정한 편지가 삭제되면 재추첨하지 않고 하루 종일 잠긴다")
+    void deletedPinnedLetter_locksForRestOfDay() {
+        long userId = 102L;
+        Letter pinnedLetter = mockLetter(20L, "고정된 편지 본문입니다. 오늘 하루도 힘내세요!");
+
+        when(letterRepository.findPinnedLetterByUser(userId)).thenReturn(Optional.of(pinnedLetter));
+
+        RandomLetterResponseDTO pinned = service.getTodayRandomLetter(userId);
+        assertThat(pinned.hasLetter()).isTrue();
+        assertThat(pinned.letterId()).isEqualTo(20L);
+        assertThat(pinned.isPinned()).isTrue();
+
+        when(letterRepository.findPinnedLetterByUser(userId)).thenReturn(Optional.empty());
+        when(letterRepository.findIsPinnedByUserIdAndLetterId(userId, 20L)).thenReturn(Optional.empty());
+
+        RandomLetterResponseDTO afterDelete = service.getTodayRandomLetter(userId);
+        assertThat(afterDelete.hasLetter()).isFalse();
+
+        RandomLetterResponseDTO stillLocked = service.getTodayRandomLetter(userId);
+        assertThat(stillLocked.hasLetter()).isFalse();
+
+        verify(letterRepository, never()).countVisibleLettersByUser(anyLong());
+        verify(letterRepository, never()).findRandomLetterByUser(anyLong(), anyLong());
+    }
+
+    @Test
+    @DisplayName("C. 고정 해제 후 유예 중이던 편지가 삭제되면 재추첨하지 않고 하루 종일 잠긴다")
+    void deletedGracedLetter_locksForRestOfDay() {
+        long userId = 103L;
+        Letter letter = mockLetter(30L, "유예 중인 편지 본문입니다. 오늘 하루도 힘내세요!");
+
+        when(letterRepository.findPinnedLetterByUser(userId)).thenReturn(Optional.of(letter));
+        RandomLetterResponseDTO pinnedResult = service.getTodayRandomLetter(userId);
+        assertThat(pinnedResult.isPinned()).isTrue();
+
+        when(letterRepository.findPinnedLetterByUser(userId)).thenReturn(Optional.empty());
+        when(letterRepository.findIsPinnedByUserIdAndLetterId(userId, 30L)).thenReturn(Optional.of(false));
+
+        RandomLetterResponseDTO gracedResult = service.getTodayRandomLetter(userId);
+        assertThat(gracedResult.hasLetter()).isTrue();
+        assertThat(gracedResult.letterId()).isEqualTo(30L);
+        assertThat(gracedResult.isPinned()).isFalse();
+
+        when(letterRepository.findIsPinnedByUserIdAndLetterId(userId, 30L)).thenReturn(Optional.empty());
+
+        RandomLetterResponseDTO afterDelete = service.getTodayRandomLetter(userId);
+        assertThat(afterDelete.hasLetter()).isFalse();
+
+        RandomLetterResponseDTO stillLocked = service.getTodayRandomLetter(userId);
+        assertThat(stillLocked.hasLetter()).isFalse();
+
+        verify(letterRepository, never()).countVisibleLettersByUser(anyLong());
+    }
+
+    @Test
+    @DisplayName("고정 캐시가 손상된 경우에는 잠그지 않고 정상적으로 새로 추첨한다")
+    void corruptedPinnedCache_doesNotLockOut() {
+        long userId = 104L;
+        store.put(pinnedKeyOf(userId), "이것은-유효한-JSON이-아님");
+
+        Letter letter = mockLetter(40L, "정상적으로 새로 뽑힌 편지 본문입니다. 오늘도 힘내세요!");
+
+        when(letterRepository.findPinnedLetterByUser(userId)).thenReturn(Optional.empty());
+        when(letterRepository.countVisibleLettersByUser(userId)).thenReturn(1L);
+        when(letterRepository.findRandomLetterByUser(eq(userId), anyLong())).thenReturn(Optional.of(letter));
+        when(letterRepository.findIsPinnedByUserIdAndLetterId(userId, 40L)).thenReturn(Optional.of(false));
+
+        RandomLetterResponseDTO result = service.getTodayRandomLetter(userId);
+
+        assertThat(result.hasLetter()).isTrue();
+        assertThat(result.letterId()).isEqualTo(40L);
+        assertThat(store.containsKey(pinnedKeyOf(userId))).isFalse();
+    }
+
+    @Test
+    @DisplayName("동시 추첨 경쟁에서 진 요청은 락아웃 센티널을 무시하지 않고 존중한다")
+    void concurrentDraw_respectsLockoutWrittenByOtherRequest() {
+        long userId = 105L;
+        Letter letter = mockLetter(50L, "동시성 테스트용 편지 본문입니다. 오늘도 힘내세요!");
+        String key = dateKeyOf(userId);
+
+        when(letterRepository.findPinnedLetterByUser(userId)).thenReturn(Optional.empty());
+        when(letterRepository.countVisibleLettersByUser(userId)).thenReturn(1L);
+        when(letterRepository.findRandomLetterByUser(eq(userId), anyLong())).thenReturn(Optional.of(letter));
+
+        when(valueOperations.setIfAbsent(eq(key), anyString(), any(Duration.class)))
+                .thenAnswer(inv -> {
+                    store.put(key, "{\"letterId\":null,\"randomPhrase\":null}");
+                    return false;
+                });
+
+        RandomLetterResponseDTO result = service.getTodayRandomLetter(userId);
+
+        assertThat(result.hasLetter()).isFalse();
+        assertThat(result.letterId()).isNull();
+    }
+
+    @Test
+    @DisplayName("고정 우선순위: 이미 뽑힌 일반 편지가 있어도 새로 고정하면 즉시 그 편지를 보여준다")
+    void pinningNewLetter_overridesExistingDraw() {
+        long userId = 106L;
+        Letter drawn = mockLetter(60L, "일반 추첨 편지 본문입니다. 오늘도 힘내세요!");
+        Letter pinned = mockLetter(61L, "고정된 편지 본문입니다. 늘 응원합니다!");
+
+        when(letterRepository.findPinnedLetterByUser(userId)).thenReturn(Optional.empty());
+        when(letterRepository.countVisibleLettersByUser(userId)).thenReturn(2L);
+        when(letterRepository.findRandomLetterByUser(eq(userId), anyLong())).thenReturn(Optional.of(drawn));
+        when(letterRepository.findIsPinnedByUserIdAndLetterId(userId, 60L)).thenReturn(Optional.of(false));
+
+        RandomLetterResponseDTO before = service.getTodayRandomLetter(userId);
+        assertThat(before.letterId()).isEqualTo(60L);
+
+        when(letterRepository.findPinnedLetterByUser(userId)).thenReturn(Optional.of(pinned));
+
+        RandomLetterResponseDTO afterPin = service.getTodayRandomLetter(userId);
+        assertThat(afterPin.letterId()).isEqualTo(61L);
+        assertThat(afterPin.isPinned()).isTrue();
+    }
+}


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 요약 -->

- 랜덤 편지 재추첨 로직 수정

---

## 🔗 관련 이슈
<!-- 관련 이슈 번호 -->

- Closes #244

---

## 🛠 변경 사항
<!-- 핵심 변경 내용 -->

1. 고정 X
-1) 추첨됐던 편지가 삭제
2. 고정 O
-1) 고정 중인 편지가 삭제
-2) 고정 해제 시 그 날은 랜덤 편지로 유지되는 상황에서 삭제 (말이 이상한데... 사용자가 고정 해제해도 그 날은 그 편지가 랜덤 편지로 유지되고, 다음 날 바뀜! 근데 이 유지되는 날에 해당 편지를 삭제하는 경우)

이렇게 3가지 케이스가 랜덤 편지를 재추첨하던 케이스인데, 이 셋 모두 hasLetter: false로 내려줄 수 있도록 수정했습니다~!

---

## ⚠️ 리뷰 시 참고 사항
<!-- 리뷰어가 봐줬으면 하는 부분 -->

- 코드가 적절히 작성되었는지

---

## ✅ 체크리스트
- [X] 로컬에서 정상 실행됨
- [X] 로그 / 네이밍 정리
- [X] main / develop 직접 커밋 아님


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 오늘의 랜덤 편지 선정이 고정 상태와 캐시 상태 변경을 정확히 반영하도록 개선되었습니다.
  * 삭제되었거나 더 이상 고정되지 않은 편지가 오늘 다시 표시되지 않도록 처리됩니다.
  * 손상된 캐시 데이터가 자동으로 재생성됩니다.
  * 표시할 편지가 없는 경우 오늘의 편지 노출이 중단됩니다.
  * 최신 고정 상태가 편지 응답에 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->