### PR TITLE
[FIX] from-api 수정

### DIFF
--- a/src/main/java/com/deare/backend/api/from/dto/request/FromCreateRequestDTO.java
+++ b/src/main/java/com/deare/backend/api/from/dto/request/FromCreateRequestDTO.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Size;
 public record FromCreateRequestDTO(
 
         @NotBlank(message = "From 이름은 필수입니다.")
-        @Size(max = 7, message = "From 이름은 최대 7자까지 가능합니다.")
+        @Size(max = 10, message = "From 이름은 최대 10자까지 가능합니다.")
         String name,
 
         @NotBlank(message = "배경색은 필수입니다.")

--- a/src/main/java/com/deare/backend/api/from/dto/request/FromUpdateRequestDTO.java
+++ b/src/main/java/com/deare/backend/api/from/dto/request/FromUpdateRequestDTO.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Size;
 
 public record FromUpdateRequestDTO(
         @NotBlank(message = "From 이름은 공백일 수 없습니다.")
-        @Size(min = 1, max = 7, message = "From 이름은 1자 이상 7자 이하여야 합니다.")
+        @Size(min = 1, max = 10, message = "From 이름은 1자 이상 10자 이하여야 합니다.")
         String name,
 
         @Pattern(

--- a/src/main/java/com/deare/backend/api/from/service/FromService.java
+++ b/src/main/java/com/deare/backend/api/from/service/FromService.java
@@ -40,6 +40,10 @@ public class FromService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
 
+        if (fromRepository.existsByUser_IdAndNameAndIsDeletedFalse(userId, request.name())) {
+            throw new GeneralException(FromErrorCode.FROM_40901);
+        }
+
         From from = new From(
                 request.name(),
                 request.bgColor(),
@@ -73,7 +77,10 @@ public class FromService {
             throw new GeneralException(FromErrorCode.FROM_40001);
         }
 
-        if (nameProvided) {
+        if (nameProvided && !request.name().equals(from.getName())) {
+            if (fromRepository.existsByUser_IdAndNameAndIsDeletedFalse(userId, request.name())) {
+                throw new GeneralException(FromErrorCode.FROM_40901);
+            }
             from.changeFromName(request.name());
         }
 

--- a/src/main/java/com/deare/backend/domain/from/entity/From.java
+++ b/src/main/java/com/deare/backend/domain/from/entity/From.java
@@ -22,7 +22,7 @@ public class From extends BaseEntity {
     @Column(name="user_from_id")
     private Long id;
 
-    @Column(name="from_name", nullable = false, length = 7)
+    @Column(name="from_name", nullable = false, length = 10)
     private String name;
 
     @Column(name="from_bg_color", nullable = false, length = 16)

--- a/src/main/java/com/deare/backend/domain/from/exception/FromErrorCode.java
+++ b/src/main/java/com/deare/backend/domain/from/exception/FromErrorCode.java
@@ -25,6 +25,12 @@ public enum FromErrorCode implements BaseErrorCode {
             "프롬 접근 권한이 없습니다."
     ),
 
+    FROM_40901(
+            HttpStatus.CONFLICT,
+            "FROM_40901",
+            "이미 존재하는 From 이름입니다."
+    ),
+
     FROM_40401(
             HttpStatus.NOT_FOUND,
             "FROM_40401",

--- a/src/main/java/com/deare/backend/domain/from/repository/FromRepository.java
+++ b/src/main/java/com/deare/backend/domain/from/repository/FromRepository.java
@@ -14,6 +14,8 @@ public interface FromRepository extends JpaRepository<From, Long> {
 
     Optional<From> findByIdAndIsDeletedFalse(Long fromId);
 
+    boolean existsByUser_IdAndNameAndIsDeletedFalse(Long userId, String name);
+
     /**
      * 해당 유저의 모든 from 삭제
      */


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 요약 -->

프롬 글자수 제한 7자에서 10자로 수정 및 중복 허용안되게 UNIQUE 제약
---

## 🔗 관련 이슈
<- -->

- Closes #99 

---

## 🛠 변경 사항
<!-- 핵심 변경 내용 -->

- 기존 글자수 제한 7자에서 10자로 수정
-existsByUser_IdAndNameAndIsDeletedFalse로 중복 확인 로직 추가

---

## ⚠️ 리뷰 시 참고 사항
<!-- 리뷰어가 봐줬으면 하는 부분 -->

현재 소프트딜리트방식에는 단순 UNIQUE 방식으로 하게 되면은 soft delete 한 이름(ex 엄마라는 from 을 삭제했는데 db에는 남아있기에 똑같은 엄마라는 from 생성 불가)하기에 생성 전 검증: isDeleted = false인 것 중에서만 중복 체크하는 로직으로 처리

---

## ✅ 체크리스트
- [ ] 로컬에서 정상 실행됨
- [ ] 로그 / 네이밍 정리
- [ ] main / develop 직접 커밋 아님
