### PR TITLE
[REFACTOR] AI 응답 지연/타임아웃 개선

### DIFF
--- a/src/main/java/com/deare/backend/global/external/feign/config/FeignConfig.java
+++ b/src/main/java/com/deare/backend/global/external/feign/config/FeignConfig.java
@@ -19,7 +19,7 @@ public class FeignConfig {
     @Bean
     public Retryer feignRetryer() {
         // period, maxPeriod, maxAttempts(최초 시도 포함 총 시도 횟수)
-        return new Retryer.Default(1_000, 3_000, 3);
+        return new LoggingRetryer(1_000, 3_000, 3);
     }
 
 }

--- a/src/main/java/com/deare/backend/global/external/feign/config/FeignConfig.java
+++ b/src/main/java/com/deare/backend/global/external/feign/config/FeignConfig.java
@@ -1,5 +1,6 @@
 package com.deare.backend.global.external.feign.config;
 
+import feign.Retryer;
 import feign.codec.ErrorDecoder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,6 +14,12 @@ public class FeignConfig {
     @Bean
     public ErrorDecoder errorDecoder() {
         return new FeignErrorDecoder();
+    }
+
+    @Bean
+    public Retryer feignRetryer() {
+        // period, maxPeriod, maxAttempts(최초 시도 포함 총 시도 횟수)
+        return new Retryer.Default(1_000, 3_000, 3);
     }
 
 }

--- a/src/main/java/com/deare/backend/global/external/feign/config/FeignDevConfig.java
+++ b/src/main/java/com/deare/backend/global/external/feign/config/FeignDevConfig.java
@@ -15,6 +15,6 @@ public class FeignDevConfig {
 
     @Bean
     public feign.Request.Options feignRequestOptions() {
-        return new feign.Request.Options(10_000, 180_000);
+        return new feign.Request.Options(10_000, 30_000);
     }
 }

--- a/src/main/java/com/deare/backend/global/external/feign/config/FeignErrorDecoder.java
+++ b/src/main/java/com/deare/backend/global/external/feign/config/FeignErrorDecoder.java
@@ -44,19 +44,25 @@ public class FeignErrorDecoder implements ErrorDecoder {
             );
         }
 
-        return mapToAiException(status);
+        return mapToAiException(status, response);
 
     }
 
-    private Exception mapToAiException(int status){
+    private Exception mapToAiException(int status, Response response){
         if(status==401){
             return new ExternalApiException(ExternalApiErrorCode.AI_UNAUTHORIZED);
         }
         if(status==429){
             return new ExternalApiException(ExternalApiErrorCode.AI_RATE_LIMITED);
         }
-        if(status==504){
-            return new ExternalApiException(ExternalApiErrorCode.AI_TIMEOUT);
+        if(status==502 || status==503 || status==504){
+            return new feign.RetryableException(
+                    status,
+                    response.reason(),
+                    response.request().httpMethod(),
+                    (Long) null,
+                    response.request()
+            );
         }
         if(status>=500){
             return new ExternalApiException(ExternalApiErrorCode.AI_UPSTREAM_ERROR);

--- a/src/main/java/com/deare/backend/global/external/feign/config/FeignProdConfig.java
+++ b/src/main/java/com/deare/backend/global/external/feign/config/FeignProdConfig.java
@@ -15,6 +15,6 @@ public class FeignProdConfig {
 
     @Bean
     public feign.Request.Options feignRequestOptions() {
-        return new feign.Request.Options(10_000, 180_000);
+        return new feign.Request.Options(10_000, 30_000);
     }
 }

--- a/src/main/java/com/deare/backend/global/external/feign/config/LoggingRetryer.java
+++ b/src/main/java/com/deare/backend/global/external/feign/config/LoggingRetryer.java
@@ -1,0 +1,45 @@
+package com.deare.backend.global.external.feign.config;
+
+import feign.RetryableException;
+import feign.Retryer;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class LoggingRetryer implements Retryer {
+
+    private final long period;
+    private final long maxPeriod;
+    private final int maxAttempts;
+    private final Retryer delegate;
+    private int attempt = 1;
+
+    public LoggingRetryer(long period, long maxPeriod, int maxAttempts) {
+        this.period = period;
+        this.maxPeriod = maxPeriod;
+        this.maxAttempts = maxAttempts;
+        this.delegate = new Retryer.Default(period, maxPeriod, maxAttempts);
+    }
+
+    @Override
+    public void continueOrPropagate(RetryableException e) {
+        if (attempt < maxAttempts) {
+            log.warn(
+                    "[Feign Retry] {}/{}번째 시도 실패, 재시도 진행 - status={}, reason={}, url={}",
+                    attempt, maxAttempts, e.status(), e.getMessage(), e.request().url()
+            );
+        } else {
+            log.warn(
+                    "[Feign Retry] {}/{}번째 시도까지 모두 실패, 재시도 소진 - status={}, reason={}, url={}",
+                    attempt, maxAttempts, e.status(), e.getMessage(), e.request().url()
+            );
+        }
+
+        attempt++;
+        delegate.continueOrPropagate(e);
+    }
+
+    @Override
+    public Retryer clone() {
+        return new LoggingRetryer(period, maxPeriod, maxAttempts);
+    }
+}

--- a/src/main/java/com/deare/backend/global/external/gemini/adapter/analyze/AnalyzeAdapterImpl.java
+++ b/src/main/java/com/deare/backend/global/external/gemini/adapter/analyze/AnalyzeAdapterImpl.java
@@ -9,9 +9,11 @@ import com.deare.backend.global.external.gemini.dto.response.GeminiTextResponseD
 import com.deare.backend.global.external.gemini.dto.response.analyze.AnalyzeResponseDTO;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AnalyzeAdapterImpl implements AnalyzeAdapter {
@@ -46,6 +48,8 @@ public class AnalyzeAdapterImpl implements AnalyzeAdapter {
 
             return result;
         }catch(feign.RetryableException e){
+            log.warn("[Analyze] AI 호출 실패 (재시도 소진 또는 네트워크 장애) - status={}, message={}",
+                    e.status(), e.getMessage());
             throw new ExternalApiException(
                     ExternalApiErrorCode.AI_TIMEOUT
             );

--- a/src/main/java/com/deare/backend/global/external/gemini/adapter/analyze/AnalyzeAdapterImpl.java
+++ b/src/main/java/com/deare/backend/global/external/gemini/adapter/analyze/AnalyzeAdapterImpl.java
@@ -47,7 +47,7 @@ public class AnalyzeAdapterImpl implements AnalyzeAdapter {
             return result;
         }catch(feign.RetryableException e){
             throw new ExternalApiException(
-                    ExternalApiErrorCode.AI_CONNECTION_FAILED
+                    ExternalApiErrorCode.AI_TIMEOUT
             );
         }
         catch(ExternalApiException e){

--- a/src/main/java/com/deare/backend/global/external/gemini/adapter/ocr/OcrAdapterImpl.java
+++ b/src/main/java/com/deare/backend/global/external/gemini/adapter/ocr/OcrAdapterImpl.java
@@ -6,11 +6,13 @@ import com.deare.backend.global.external.gemini.client.GeminiFeignClient;
 import com.deare.backend.global.external.gemini.dto.request.ocr.GeminiOcrRequestDTO;
 import com.deare.backend.global.external.gemini.dto.response.GeminiTextResponseDTO;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class OcrAdapterImpl implements OcrAdapter {
@@ -47,6 +49,8 @@ public class OcrAdapterImpl implements OcrAdapter {
 
         } catch (feign.RetryableException e) {
             // 네트워크 / 타임아웃 / DNS, 또는 5xx 재시도 소진
+            log.warn("[OCR] AI 호출 실패 (재시도 소진 또는 네트워크 장애) - status={}, message={}",
+                    e.status(), e.getMessage());
             throw new ExternalApiException(ExternalApiErrorCode.AI_TIMEOUT);
         } catch (ExternalApiException e) {
             throw e;

--- a/src/main/java/com/deare/backend/global/external/gemini/adapter/ocr/OcrAdapterImpl.java
+++ b/src/main/java/com/deare/backend/global/external/gemini/adapter/ocr/OcrAdapterImpl.java
@@ -46,25 +46,12 @@ public class OcrAdapterImpl implements OcrAdapter {
             return response.getChoices().get(0).getMessage().getContent();
 
         } catch (feign.RetryableException e) {
-            // 네트워크 / 타임아웃 / DNS
-            throw new ExternalApiException(ExternalApiErrorCode.AI_CONNECTION_FAILED);
-        } catch (feign.FeignException e) {
-            int status = e.status();
-
-            if (status == 401 || status == 403) {
-                // API 키 / 인증 문제 → 배포/설정 이슈
-                throw new ExternalApiException(ExternalApiErrorCode.AI_UNAUTHORIZED);
-            }
-            if (status == 429) {
-                // rate limit → 비용/쿼터 이슈
-                throw new ExternalApiException(ExternalApiErrorCode.AI_RATE_LIMITED);
-            }
-            if (status >= 500) {
-                // Gemini 서버 장애
-                throw new ExternalApiException(ExternalApiErrorCode.AI_UPSTREAM_ERROR);
-            }
-            // 그 외 4xx 반환 → 요청 포맷/모델 문제
-            throw new ExternalApiException(ExternalApiErrorCode.AI_BAD_REQUEST);
+            // 네트워크 / 타임아웃 / DNS, 또는 5xx 재시도 소진
+            throw new ExternalApiException(ExternalApiErrorCode.AI_TIMEOUT);
+        } catch (ExternalApiException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ExternalApiException(ExternalApiErrorCode.AI_REQUEST_FAILED);
         }
 
     }


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 요약 -->

- AI 응답 문제 개선 -> 응답 대기 시간 단축 및 재시도 로직 추가


## 🔗 관련 이슈
<!-- 관련 이슈 번호 -->

- Closes #245 


## 🛠 변경 사항
<!-- 핵심 변경 내용 -->
  - FeignProdConfig, FeignDevConfig: Timeout 단축  180초->30초
  - FeignConfig: 최초 시도 포함 3회 재시도
  - FeignErrorDecoder: 502/503/504 응답을 RetryableException으로 변환해 위 Retryer가 실제로 재시도하도록 연결
  - RetryableException → AI_TIMEOUT으로 통일
  - OcrAdapterImpl에 중복돼 있던 상태코드별(401/429/5xx/4xx) 수동 분기 로직 제거 — 이제 FeignErrorDecoder가 전담


## ⚠️ 리뷰 시 참고 사항
<!-- 리뷰어가 봐줬으면 하는 부분 -->
- AI 호출 재시도 관련 로깅 코드 추가하는 게 좋을지 의견 묻고싶습니다!


## ✅ 체크리스트
- [ ] 로컬에서 정상 실행됨
- [ ] 로그 / 네이밍 정리
- [ ] main / develop 직접 커밋 아님
