### PR TITLE
[REFACTOR] 랜덤 편지 추첨 시 당일 만들어진 편지는 추첨하지 않도록 변경

### DIFF
--- a/src/main/java/com/deare/backend/api/letter/service/RandomLetterService.java
+++ b/src/main/java/com/deare/backend/api/letter/service/RandomLetterService.java
@@ -240,7 +240,10 @@ public class RandomLetterService {
     }
 
     private RandomLetterResponseDTO createAndCache(long userId, LocalDate today, String key) {
-        long count = letterRepository.countVisibleLettersByUser(userId);
+        // 오늘 만들어진 편지는 당일 추첨 후보에서 제외
+        LocalDateTime todayStart = today.atStartOfDay();
+
+        long count = letterRepository.countVisibleLettersByUser(userId, todayStart);
 
         // 편지가 없으면 캐시 저장 없이 바로 응답
         if (count == 0) {
@@ -258,7 +261,7 @@ public class RandomLetterService {
 
         // offset 기반으로 1개 조회
         Letter letter = letterRepository
-                .findRandomLetterByUser(userId, offset)
+                .findRandomLetterByUser(userId, offset, todayStart)
                 .orElseThrow(() -> new GeneralException(LetterErrorCode.LETTER_NOT_FOUND));
 
         // 편지 본문에서 랜덤 문구 추출

--- a/src/main/java/com/deare/backend/domain/letter/repository/LetterRepositoryCustom.java
+++ b/src/main/java/com/deare/backend/domain/letter/repository/LetterRepositoryCustom.java
@@ -4,6 +4,7 @@ import com.deare.backend.domain.letter.entity.Letter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface LetterRepositoryCustom {
@@ -18,9 +19,9 @@ public interface LetterRepositoryCustom {
 
     Optional<Letter> findLetterDetailById(Long userId, Long letterId);
 
-    Optional<Letter> findRandomLetterByUser(Long userId, long offset);
+    Optional<Letter> findRandomLetterByUser(Long userId, long offset, LocalDateTime createdBefore);
 
-    long countVisibleLettersByUser(Long userId);
+    long countVisibleLettersByUser(Long userId, LocalDateTime createdBefore);
 
     Optional<Letter> findPinnedLetterByUser(Long userId);
 }

--- a/src/main/java/com/deare/backend/domain/letter/repository/LetterRepositoryImpl.java
+++ b/src/main/java/com/deare/backend/domain/letter/repository/LetterRepositoryImpl.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.util.StringUtils;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -169,7 +170,7 @@ public class LetterRepositoryImpl implements LetterRepositoryCustom {
     }
 
     @Override
-    public Optional<Letter> findRandomLetterByUser(Long userId, long offset) {
+    public Optional<Letter> findRandomLetterByUser(Long userId, long offset, LocalDateTime createdBefore) {
         QLetter letter = QLetter.letter;
 
         Letter result = queryFactory
@@ -177,7 +178,8 @@ public class LetterRepositoryImpl implements LetterRepositoryCustom {
                 .where(
                         letter.user.id.eq(userId),
                         letter.isDeleted.eq(false),
-                        letter.isHidden.eq(false)
+                        letter.isHidden.eq(false),
+                        letter.createdAt.lt(createdBefore)
                 )
                 .orderBy(letter.id.asc())
                 .offset(offset)
@@ -188,7 +190,7 @@ public class LetterRepositoryImpl implements LetterRepositoryCustom {
     }
 
     @Override
-    public long countVisibleLettersByUser(Long userId) {
+    public long countVisibleLettersByUser(Long userId, LocalDateTime createdBefore) {
         QLetter letter = QLetter.letter;
 
         Long count = queryFactory
@@ -197,7 +199,8 @@ public class LetterRepositoryImpl implements LetterRepositoryCustom {
                 .where(
                         letter.user.id.eq(userId),
                         letter.isDeleted.eq(false),
-                        letter.isHidden.eq(false)
+                        letter.isHidden.eq(false),
+                        letter.createdAt.lt(createdBefore)
                 )
                 .fetchOne();
 

--- a/src/test/java/com/deare/backend/api/letter/service/RandomLetterServiceTest.java
+++ b/src/test/java/com/deare/backend/api/letter/service/RandomLetterServiceTest.java
@@ -12,6 +12,7 @@ import org.springframework.data.redis.core.ValueOperations;
 
 import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Map;
 import java.util.Optional;
@@ -92,8 +93,8 @@ class RandomLetterServiceTest {
         Letter letter = mockLetter(10L, "테스트용 편지 본문입니다. 오늘 하루도 힘내세요!");
 
         when(letterRepository.findPinnedLetterByUser(userId)).thenReturn(Optional.empty());
-        when(letterRepository.countVisibleLettersByUser(userId)).thenReturn(2L);
-        when(letterRepository.findRandomLetterByUser(eq(userId), anyLong())).thenReturn(Optional.of(letter));
+        when(letterRepository.countVisibleLettersByUser(eq(userId), any(LocalDateTime.class))).thenReturn(2L);
+        when(letterRepository.findRandomLetterByUser(eq(userId), anyLong(), any(LocalDateTime.class))).thenReturn(Optional.of(letter));
         when(letterRepository.findIsPinnedByUserIdAndLetterId(userId, 10L)).thenReturn(Optional.of(false));
 
         RandomLetterResponseDTO first = service.getTodayRandomLetter(userId);
@@ -104,7 +105,7 @@ class RandomLetterServiceTest {
         RandomLetterResponseDTO second = service.getTodayRandomLetter(userId);
         assertThat(second.letterId()).isEqualTo(10L);
 
-        verify(letterRepository, times(1)).findRandomLetterByUser(eq(userId), anyLong());
+        verify(letterRepository, times(1)).findRandomLetterByUser(eq(userId), anyLong(), any(LocalDateTime.class));
     }
 
     @Test
@@ -114,8 +115,8 @@ class RandomLetterServiceTest {
         Letter letter = mockLetter(11L, "테스트용 편지 본문입니다. 오늘 하루도 힘내세요!");
 
         when(letterRepository.findPinnedLetterByUser(userId)).thenReturn(Optional.empty());
-        when(letterRepository.countVisibleLettersByUser(userId)).thenReturn(1L);
-        when(letterRepository.findRandomLetterByUser(eq(userId), anyLong())).thenReturn(Optional.of(letter));
+        when(letterRepository.countVisibleLettersByUser(eq(userId), any(LocalDateTime.class))).thenReturn(1L);
+        when(letterRepository.findRandomLetterByUser(eq(userId), anyLong(), any(LocalDateTime.class))).thenReturn(Optional.of(letter));
         when(letterRepository.findIsPinnedByUserIdAndLetterId(userId, 11L)).thenReturn(Optional.of(false));
 
         RandomLetterResponseDTO drawn = service.getTodayRandomLetter(userId);
@@ -130,7 +131,7 @@ class RandomLetterServiceTest {
         RandomLetterResponseDTO stillLocked = service.getTodayRandomLetter(userId);
         assertThat(stillLocked.hasLetter()).isFalse();
 
-        verify(letterRepository, times(1)).findRandomLetterByUser(eq(userId), anyLong());
+        verify(letterRepository, times(1)).findRandomLetterByUser(eq(userId), anyLong(), any(LocalDateTime.class));
     }
 
     @Test
@@ -155,8 +156,8 @@ class RandomLetterServiceTest {
         RandomLetterResponseDTO stillLocked = service.getTodayRandomLetter(userId);
         assertThat(stillLocked.hasLetter()).isFalse();
 
-        verify(letterRepository, never()).countVisibleLettersByUser(anyLong());
-        verify(letterRepository, never()).findRandomLetterByUser(anyLong(), anyLong());
+        verify(letterRepository, never()).countVisibleLettersByUser(anyLong(), any(LocalDateTime.class));
+        verify(letterRepository, never()).findRandomLetterByUser(anyLong(), anyLong(), any(LocalDateTime.class));
     }
 
     @Test
@@ -185,7 +186,7 @@ class RandomLetterServiceTest {
         RandomLetterResponseDTO stillLocked = service.getTodayRandomLetter(userId);
         assertThat(stillLocked.hasLetter()).isFalse();
 
-        verify(letterRepository, never()).countVisibleLettersByUser(anyLong());
+        verify(letterRepository, never()).countVisibleLettersByUser(anyLong(), any(LocalDateTime.class));
     }
 
     @Test
@@ -197,8 +198,8 @@ class RandomLetterServiceTest {
         Letter letter = mockLetter(40L, "정상적으로 새로 뽑힌 편지 본문입니다. 오늘도 힘내세요!");
 
         when(letterRepository.findPinnedLetterByUser(userId)).thenReturn(Optional.empty());
-        when(letterRepository.countVisibleLettersByUser(userId)).thenReturn(1L);
-        when(letterRepository.findRandomLetterByUser(eq(userId), anyLong())).thenReturn(Optional.of(letter));
+        when(letterRepository.countVisibleLettersByUser(eq(userId), any(LocalDateTime.class))).thenReturn(1L);
+        when(letterRepository.findRandomLetterByUser(eq(userId), anyLong(), any(LocalDateTime.class))).thenReturn(Optional.of(letter));
         when(letterRepository.findIsPinnedByUserIdAndLetterId(userId, 40L)).thenReturn(Optional.of(false));
 
         RandomLetterResponseDTO result = service.getTodayRandomLetter(userId);
@@ -216,8 +217,8 @@ class RandomLetterServiceTest {
         String key = dateKeyOf(userId);
 
         when(letterRepository.findPinnedLetterByUser(userId)).thenReturn(Optional.empty());
-        when(letterRepository.countVisibleLettersByUser(userId)).thenReturn(1L);
-        when(letterRepository.findRandomLetterByUser(eq(userId), anyLong())).thenReturn(Optional.of(letter));
+        when(letterRepository.countVisibleLettersByUser(eq(userId), any(LocalDateTime.class))).thenReturn(1L);
+        when(letterRepository.findRandomLetterByUser(eq(userId), anyLong(), any(LocalDateTime.class))).thenReturn(Optional.of(letter));
 
         when(valueOperations.setIfAbsent(eq(key), anyString(), any(Duration.class)))
                 .thenAnswer(inv -> {
@@ -239,8 +240,8 @@ class RandomLetterServiceTest {
         Letter pinned = mockLetter(61L, "고정된 편지 본문입니다. 늘 응원합니다!");
 
         when(letterRepository.findPinnedLetterByUser(userId)).thenReturn(Optional.empty());
-        when(letterRepository.countVisibleLettersByUser(userId)).thenReturn(2L);
-        when(letterRepository.findRandomLetterByUser(eq(userId), anyLong())).thenReturn(Optional.of(drawn));
+        when(letterRepository.countVisibleLettersByUser(eq(userId), any(LocalDateTime.class))).thenReturn(2L);
+        when(letterRepository.findRandomLetterByUser(eq(userId), anyLong(), any(LocalDateTime.class))).thenReturn(Optional.of(drawn));
         when(letterRepository.findIsPinnedByUserIdAndLetterId(userId, 60L)).thenReturn(Optional.of(false));
 
         RandomLetterResponseDTO before = service.getTodayRandomLetter(userId);


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 요약 -->

- 랜덤 편지 추첨 시 당일 만들어진 편지는 추첨하지 않도록 변경

---

## 🔗 관련 이슈
<!-- 관련 이슈 번호 -->

- Closes #252

---

## 🛠 변경 사항
<!-- 핵심 변경 내용 -->

- 사용자가 최초 가입하여 소유한 편지가 0개일 때, 새로운 편지를 생성하면 cache가 미존재하고, 랜덤 편지를 뽑은 적이 없기 때문에 무조건 처음 생성한 편지가 추첨되는 상황이 발생했습니다.
- 이를 해결하기 위해 랜덤 편지 추첨 시 당일 만들어진 편지는 추첨하지 않도록 변경했습니다.

---

## ⚠️ 리뷰 시 참고 사항
<!-- 리뷰어가 봐줬으면 하는 부분 -->

- 기존 로직에 방해가 되지 않는지

---

## ✅ 체크리스트
- [x] 로컬에서 정상 실행됨
- [x] 로그 / 네이밍 정리
- [x] main / develop 직접 커밋 아님
