### PR TITLE
[FEAT] 리포트 분석 엔티티 및 테이블 구현

### DIFF
--- a/src/main/java/com/deare/backend/domain/report/entity/ReportAnalysis.java
+++ b/src/main/java/com/deare/backend/domain/report/entity/ReportAnalysis.java
@@ -1,0 +1,80 @@
+package com.deare.backend.domain.report.entity;
+
+import com.deare.backend.domain.user.entity.User;
+import com.deare.backend.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "report_analysis",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_report_analysis_user",
+                        columnNames = {"user_id"}
+                )
+        }
+)
+public class ReportAnalysis extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_analysis_id")
+    private Long id;
+
+    @Column(name = "description", nullable = false, length = 200)
+    private String description;
+
+    @Column(name = "hashtag1", nullable = false, length = 50)
+    private String hashtag1;
+
+    @Column(name = "hashtag2", nullable = false, length = 50)
+    private String hashtag2;
+
+    @Column(name = "analyzed_letter_count", nullable = false)
+    private int analyzedLetterCount;
+
+    @Column(name = "analyzed_at", nullable = false)
+    private LocalDateTime analyzedAt;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public ReportAnalysis(
+            User user,
+            String description,
+            String hashtag1,
+            String hashtag2,
+            int analyzedLetterCount,
+            LocalDateTime analyzedAt
+    ) {
+        this.user = user;
+        this.description = description;
+        this.hashtag1 = hashtag1;
+        this.hashtag2 = hashtag2;
+        this.analyzedLetterCount = analyzedLetterCount;
+        this.analyzedAt = analyzedAt;
+    }
+
+
+    public void reanalyze(
+            String description,
+            String hashtag1,
+            String hashtag2,
+            int analyzedLetterCount,
+            LocalDateTime analyzedAt
+    ) {
+        this.description = description;
+        this.hashtag1 = hashtag1;
+        this.hashtag2 = hashtag2;
+        this.analyzedLetterCount = analyzedLetterCount;
+        this.analyzedAt = analyzedAt;
+    }
+}

--- a/src/main/java/com/deare/backend/domain/report/entity/ReportAnalysis.java
+++ b/src/main/java/com/deare/backend/domain/report/entity/ReportAnalysis.java
@@ -3,6 +3,7 @@ package com.deare.backend.domain.report.entity;
 import com.deare.backend.domain.user.entity.User;
 import com.deare.backend.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Min;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -37,6 +38,7 @@ public class ReportAnalysis extends BaseEntity {
     @Column(name = "hashtag2", nullable = false, length = 50)
     private String hashtag2;
 
+    @Min(0)
     @Column(name = "analyzed_letter_count", nullable = false)
     private int analyzedLetterCount;
 
@@ -71,6 +73,9 @@ public class ReportAnalysis extends BaseEntity {
             int analyzedLetterCount,
             LocalDateTime analyzedAt
     ) {
+        if(analyzedLetterCount<0){
+            throw new IllegalArgumentException("분석된 편지 개수는 음수일 수 없습니다.");
+        }
         this.description = description;
         this.hashtag1 = hashtag1;
         this.hashtag2 = hashtag2;

--- a/src/main/java/com/deare/backend/domain/report/repository/ReportAnalysisRepository.java
+++ b/src/main/java/com/deare/backend/domain/report/repository/ReportAnalysisRepository.java
@@ -1,0 +1,20 @@
+package com.deare.backend.domain.report.repository;
+
+import com.deare.backend.domain.report.entity.ReportAnalysis;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ReportAnalysisRepository extends JpaRepository<ReportAnalysis, Long> {
+    Optional<ReportAnalysis> findByUserId(Long userId);
+
+
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("DELETE FROM ReportAnalysis r WHERE r.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
+}

--- a/src/main/resources/db/migration/V7__create_report_analysis_table.sql
+++ b/src/main/resources/db/migration/V7__create_report_analysis_table.sql
@@ -1,0 +1,21 @@
+-- =============================================
+-- V7: report_analysis 테이블 생성
+-- AI가 편지 3통 이상을 바탕으로 생성하는 유저 성향 분석(1인 1행, 재분석 시 덮어쓰기)
+-- =============================================
+
+CREATE TABLE IF NOT EXISTS report_analysis (
+    report_analysis_id   BIGINT       NOT NULL AUTO_INCREMENT,
+    user_id               BIGINT       NOT NULL,
+    description            VARCHAR(200) NOT NULL,
+    hashtag1                VARCHAR(50)  NOT NULL,
+    hashtag2                VARCHAR(50)  NOT NULL,
+    analyzed_letter_count  INT          NOT NULL,
+    analyzed_at            DATETIME(6)  NOT NULL,
+    created_at             DATETIME(6)  NOT NULL,
+    updated_at             DATETIME(6)  NOT NULL,
+    deleted_at             DATETIME(6),
+    is_deleted             BOOLEAN      NOT NULL DEFAULT FALSE,
+    PRIMARY KEY (report_analysis_id),
+    UNIQUE KEY uq_report_analysis_user (user_id),
+    CONSTRAINT fk_report_analysis_user FOREIGN KEY (user_id) REFERENCES users (user_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/main/resources/db/migration/V7__create_report_analysis_table.sql
+++ b/src/main/resources/db/migration/V7__create_report_analysis_table.sql
@@ -1,8 +1,3 @@
--- =============================================
--- V7: report_analysis 테이블 생성
--- AI가 편지 3통 이상을 바탕으로 생성하는 유저 성향 분석(1인 1행, 재분석 시 덮어쓰기)
--- =============================================
-
 CREATE TABLE IF NOT EXISTS report_analysis (
     report_analysis_id   BIGINT       NOT NULL AUTO_INCREMENT,
     user_id               BIGINT       NOT NULL,

--- a/src/main/resources/db/migration/V7__create_report_analysis_table.sql
+++ b/src/main/resources/db/migration/V7__create_report_analysis_table.sql
@@ -12,5 +12,6 @@ CREATE TABLE IF NOT EXISTS report_analysis (
     is_deleted             BOOLEAN      NOT NULL DEFAULT FALSE,
     PRIMARY KEY (report_analysis_id),
     UNIQUE KEY uq_report_analysis_user (user_id),
+    CONSTRAINT chk_report_analysis_analyzed_letter_count CHECK (analyzed_letter_count>=0),
     CONSTRAINT fk_report_analysis_user FOREIGN KEY (user_id) REFERENCES users (user_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 요약 -->

- 리포트 조회 및 AI 재분석 기능 구현을 위한 리포트 도메인 및 테이블 마이그레이션 추가


## 🔗 관련 이슈
<!-- 관련 이슈 번호 -->

- Closes #268 


## 🛠 변경 사항
<!-- 핵심 변경 내용 -->

- `ReportAnalysis` 엔티티 추가
    - 재분석 결과 반영용 reanalyze() 도메인 메서드 추가
- `ReportAnalysisRepository` 추가 -> 구현체는 기능 구현과 함께 추가 예정
- `V7__create_report_analysis_table.sql` 마이그레이션 추가


## ⚠️ 리뷰 시 참고 사항
<!-- 리뷰어가 봐줬으면 하는 부분 -->
#### 테이블 구조
<img width="570" height="254" alt="image" src="https://github.com/user-attachments/assets/a0a21546-6e30-42e2-9161-a19e9b2748fa" />


## ✅ 체크리스트
- [ ] 로컬에서 정상 실행됨
- [ ] 로그 / 네이밍 정리
- [ ] main / develop 직접 커밋 아님
