### PR TITLE
[FEAT] 폴더 편지 일괄 이동 및 추가 가능 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/deare/backend/api/folder/controller/FolderController.java
+++ b/src/main/java/com/deare/backend/api/folder/controller/FolderController.java
@@ -6,6 +6,9 @@ import com.deare.backend.api.folder.dto.response.FolderListResponseDTO;
 import com.deare.backend.api.folder.dto.request.FolderOrderRequestDTO;
 import com.deare.backend.api.folder.dto.request.FolderUpdateRequestDTO;
 import com.deare.backend.api.folder.dto.response.FolderOrderResponseDTO;
+import com.deare.backend.api.folder.dto.request.FolderLettersRequestDTO;
+import com.deare.backend.api.folder.dto.response.FolderLettersResponseDTO;
+import com.deare.backend.api.letter.dto.response.LetterListResponseDTO;
 import com.deare.backend.api.folder.service.FolderService;
 import com.deare.backend.global.auth.util.SecurityUtil;
 import com.deare.backend.global.common.response.ApiResponse;
@@ -13,6 +16,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.data.domain.Pageable;
 
 @RestController
 @RequestMapping("/folders")
@@ -84,6 +88,26 @@ public class FolderController {
         Long userId = SecurityUtil.getCurrentUserId();
         folderService.addLetterToFolder(userId, folderId, letterId);
         return ApiResponse.success(null);
+    }
+
+    @PostMapping("/{folderId}/letters")
+    public ApiResponse<FolderLettersResponseDTO> addLettersToFolder(@PathVariable Long folderId, @Valid @RequestBody FolderLettersRequestDTO reqDTO) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        FolderLettersResponseDTO data = folderService.addLettersToFolder(userId, folderId, reqDTO);
+        return ApiResponse.success("COMMON200", "편지가 폴더에 추가되었습니다.", data);
+    }
+
+    @GetMapping("/{folderId}/letters/available")
+    public ApiResponse<LetterListResponseDTO> getAvailableLetters(
+            @PathVariable Long folderId,
+            Pageable pageable,
+            @RequestParam(required = false) Long fromId,
+            @RequestParam(required = false) Boolean isLiked,
+            @RequestParam(required = false) String keyword
+    ) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        LetterListResponseDTO data = folderService.getAvailableLetters(pageable, userId, folderId, fromId, isLiked, keyword);
+        return ApiResponse.success("COMMON200", "추가 가능한 편지 목록 조회에 성공했습니다.", data);
     }
 
     @DeleteMapping("/{folderId}/letters/{letterId}")

--- a/src/main/java/com/deare/backend/api/folder/controller/FolderController.java
+++ b/src/main/java/com/deare/backend/api/folder/controller/FolderController.java
@@ -94,7 +94,7 @@ public class FolderController {
     public ApiResponse<FolderLettersResponseDTO> addLettersToFolder(@PathVariable Long folderId, @Valid @RequestBody FolderLettersRequestDTO reqDTO) {
         Long userId = SecurityUtil.getCurrentUserId();
         FolderLettersResponseDTO data = folderService.addLettersToFolder(userId, folderId, reqDTO);
-        return ApiResponse.success("COMMON200", "편지가 폴더에 추가되었습니다.", data);
+        return ApiResponse.success("편지가 폴더에 추가되었습니다.", data);
     }
 
     @GetMapping("/{folderId}/letters/available")
@@ -107,7 +107,7 @@ public class FolderController {
     ) {
         Long userId = SecurityUtil.getCurrentUserId();
         LetterListResponseDTO data = folderService.getAvailableLetters(pageable, userId, folderId, fromId, isLiked, keyword);
-        return ApiResponse.success("COMMON200", "추가 가능한 편지 목록 조회에 성공했습니다.", data);
+        return ApiResponse.success("추가 가능한 편지 목록 조회에 성공했습니다.", data);
     }
 
     @DeleteMapping("/{folderId}/letters/{letterId}")

--- a/src/main/java/com/deare/backend/api/folder/dto/request/FolderLettersRequestDTO.java
+++ b/src/main/java/com/deare/backend/api/folder/dto/request/FolderLettersRequestDTO.java
@@ -1,0 +1,13 @@
+package com.deare.backend.api.folder.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.util.List;
+
+public record FolderLettersRequestDTO(
+        @NotEmpty
+        List<@NotNull @Positive Long> letterIds
+) {
+}

--- a/src/main/java/com/deare/backend/api/folder/dto/response/FolderLettersResponseDTO.java
+++ b/src/main/java/com/deare/backend/api/folder/dto/response/FolderLettersResponseDTO.java
@@ -1,0 +1,7 @@
+package com.deare.backend.api.folder.dto.response;
+
+public record FolderLettersResponseDTO(
+        Long folderId,
+        int processedCount
+) {
+}

--- a/src/main/java/com/deare/backend/api/folder/service/FolderService.java
+++ b/src/main/java/com/deare/backend/api/folder/service/FolderService.java
@@ -6,6 +6,10 @@ import com.deare.backend.api.folder.dto.response.FolderListResponseDTO;
 import com.deare.backend.api.folder.dto.response.FolderOrderResponseDTO;
 import com.deare.backend.api.folder.dto.request.FolderOrderRequestDTO;
 import com.deare.backend.api.folder.dto.request.FolderUpdateRequestDTO;
+import com.deare.backend.api.folder.dto.request.FolderLettersRequestDTO;
+import com.deare.backend.api.folder.dto.response.FolderLettersResponseDTO;
+import com.deare.backend.api.letter.dto.response.LetterListResponseDTO;
+import org.springframework.data.domain.Pageable;
 
 public interface FolderService {
 
@@ -14,6 +18,8 @@ public interface FolderService {
             Long userId, FolderCreateRequestDTO req);
     void deleteFolder(Long userId, Long folderId);
     void addLetterToFolder(Long userId, Long folderId, Long letterId);
+    FolderLettersResponseDTO addLettersToFolder(Long userId, Long folderId, FolderLettersRequestDTO reqDTO);
+    LetterListResponseDTO getAvailableLetters(Pageable pageable, Long userId, Long folderId, Long fromId, Boolean isLiked, String keyword);
     void removeLetterFromFolder(Long userId, Long folderId, Long letterId);
     FolderOrderResponseDTO updateOrders(Long userId, FolderOrderRequestDTO reqDTO);
     void updateFolder(Long userId, Long folderId, FolderUpdateRequestDTO reqDTO);

--- a/src/main/java/com/deare/backend/api/folder/service/FolderServiceImpl.java
+++ b/src/main/java/com/deare/backend/api/folder/service/FolderServiceImpl.java
@@ -6,7 +6,13 @@ import com.deare.backend.api.folder.dto.request.FolderUpdateRequestDTO;
 import com.deare.backend.api.folder.dto.response.FolderCreateResponseDTO;
 import com.deare.backend.api.folder.dto.response.FolderListResponseDTO;
 import com.deare.backend.api.folder.dto.response.FolderOrderResponseDTO;
+import com.deare.backend.api.folder.dto.request.FolderLettersRequestDTO;
+import com.deare.backend.api.folder.dto.response.FolderLettersResponseDTO;
 import com.deare.backend.api.folder.dto.result.FolderItemDTO;
+import com.deare.backend.api.letter.dto.response.LetterListResponseDTO;
+import com.deare.backend.api.letter.dto.result.LetterFromDTO;
+import com.deare.backend.api.letter.dto.result.LetterItemDTO;
+import com.deare.backend.api.letter.util.ExcerptUtil;
 import com.deare.backend.domain.folder.entity.Folder;
 import com.deare.backend.domain.folder.exception.FolderErrorCode;
 import com.deare.backend.domain.folder.repository.FolderRepository;
@@ -22,15 +28,20 @@ import com.deare.backend.global.common.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
 public class FolderServiceImpl implements FolderService {
 
     private static final int MAX_FOLDERS = 3;
+    private static final int EXCERPT_MAX_CHARS = 100;
 
     private final FolderRepository folderRepository;
     private final ImageRepository imageRepository;
@@ -118,6 +129,47 @@ public class FolderServiceImpl implements FolderService {
 
     @Override
     @Transactional
+    public FolderLettersResponseDTO addLettersToFolder(Long userId, Long folderId, FolderLettersRequestDTO reqDTO) {
+        Folder folder = getOwnedActiveFolder(userId, folderId);
+        Set<Long> distinctIds = new LinkedHashSet<>(reqDTO.letterIds());
+        List<Letter> letters = letterRepository.findAllById(distinctIds);
+
+        if (letters.size() != distinctIds.size() || letters.stream().anyMatch(Letter::isDeleted)) {
+            throw new GeneralException(LetterErrorCode.LETTER_NOT_FOUND);
+        }
+        if (letters.stream().anyMatch(letter -> !letter.isOwnedBy(userId))) {
+            throw new GeneralException(LetterErrorCode.FORBIDDEN);
+        }
+
+        letters.forEach(letter -> letter.changeFolder(folder));
+        return new FolderLettersResponseDTO(folderId, distinctIds.size());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public LetterListResponseDTO getAvailableLetters(
+            Pageable pageable,
+            Long userId,
+            Long folderId,
+            Long fromId,
+            Boolean isLiked,
+            String keyword
+    ) {
+        getOwnedActiveFolder(userId, folderId);
+        Page<Letter> page = letterRepository.findAvailableLetters(userId, folderId, fromId, isLiked, keyword, pageable);
+        List<LetterItemDTO> items = page.getContent().stream().map(this::toLetterItemDTO).toList();
+
+        return new LetterListResponseDTO(
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.getSize(),
+                page.getNumber(),
+                items
+        );
+    }
+
+    @Override
+    @Transactional
     public void removeLetterFromFolder(Long userId, Long folderId, Long letterId) {
         folderRepository.findByIdAndUser_IdAndIsDeletedFalse(folderId, userId)
                 .orElseThrow(() -> new GeneralException(FolderErrorCode.FOLDER_NOT_FOUND));
@@ -199,6 +251,34 @@ public class FolderServiceImpl implements FolderService {
 
             case DELETE -> folder.changeImage(null);
         }
+    }
+
+    private Folder getOwnedActiveFolder(Long userId, Long folderId) {
+        Folder folder = folderRepository.findById(folderId)
+                .filter(found -> !found.isDeleted())
+                .orElseThrow(() -> new GeneralException(FolderErrorCode.FOLDER_NOT_FOUND));
+
+        if (!folder.getUser().getId().equals(userId)) {
+            throw new GeneralException(FolderErrorCode.FORBIDDEN);
+        }
+        return folder;
+    }
+
+    private LetterItemDTO toLetterItemDTO(Letter letter) {
+        return new LetterItemDTO(
+                letter.getId(),
+                ExcerptUtil.excerptByChars(letter.getContent(), EXCERPT_MAX_CHARS),
+                letter.isLiked(),
+                letter.getReceivedAt(),
+                letter.getCreatedAt(),
+                new LetterFromDTO(
+                        letter.getFrom().getId(),
+                        letter.getFrom().getName(),
+                        letter.getFrom().getBackgroundColor(),
+                        letter.getFrom().getFontColor()
+                ),
+                letter.getFolder() != null ? letter.getFolder().getId() : null
+        );
     }
 
 }

--- a/src/main/java/com/deare/backend/api/folder/service/FolderServiceImpl.java
+++ b/src/main/java/com/deare/backend/api/folder/service/FolderServiceImpl.java
@@ -10,9 +10,8 @@ import com.deare.backend.api.folder.dto.request.FolderLettersRequestDTO;
 import com.deare.backend.api.folder.dto.response.FolderLettersResponseDTO;
 import com.deare.backend.api.folder.dto.result.FolderItemDTO;
 import com.deare.backend.api.letter.dto.response.LetterListResponseDTO;
-import com.deare.backend.api.letter.dto.result.LetterFromDTO;
 import com.deare.backend.api.letter.dto.result.LetterItemDTO;
-import com.deare.backend.api.letter.util.ExcerptUtil;
+import com.deare.backend.api.letter.mapper.LetterItemMapper;
 import com.deare.backend.domain.folder.entity.Folder;
 import com.deare.backend.domain.folder.exception.FolderErrorCode;
 import com.deare.backend.domain.folder.repository.FolderRepository;
@@ -41,8 +40,6 @@ import java.util.Set;
 public class FolderServiceImpl implements FolderService {
 
     private static final int MAX_FOLDERS = 3;
-    private static final int EXCERPT_MAX_CHARS = 100;
-
     private final FolderRepository folderRepository;
     private final ImageRepository imageRepository;
     private final UserRepository userRepository;
@@ -157,7 +154,7 @@ public class FolderServiceImpl implements FolderService {
     ) {
         getOwnedActiveFolder(userId, folderId);
         Page<Letter> page = letterRepository.findAvailableLetters(userId, folderId, fromId, isLiked, keyword, pageable);
-        List<LetterItemDTO> items = page.getContent().stream().map(this::toLetterItemDTO).toList();
+        List<LetterItemDTO> items = page.getContent().stream().map(LetterItemMapper::toItemDTO).toList();
 
         return new LetterListResponseDTO(
                 page.getTotalElements(),
@@ -262,23 +259,6 @@ public class FolderServiceImpl implements FolderService {
             throw new GeneralException(FolderErrorCode.FORBIDDEN);
         }
         return folder;
-    }
-
-    private LetterItemDTO toLetterItemDTO(Letter letter) {
-        return new LetterItemDTO(
-                letter.getId(),
-                ExcerptUtil.excerptByChars(letter.getContent(), EXCERPT_MAX_CHARS),
-                letter.isLiked(),
-                letter.getReceivedAt(),
-                letter.getCreatedAt(),
-                new LetterFromDTO(
-                        letter.getFrom().getId(),
-                        letter.getFrom().getName(),
-                        letter.getFrom().getBackgroundColor(),
-                        letter.getFrom().getFontColor()
-                ),
-                letter.getFolder() != null ? letter.getFolder().getId() : null
-        );
     }
 
 }

--- a/src/main/java/com/deare/backend/api/letter/mapper/LetterItemMapper.java
+++ b/src/main/java/com/deare/backend/api/letter/mapper/LetterItemMapper.java
@@ -1,0 +1,31 @@
+package com.deare.backend.api.letter.mapper;
+
+import com.deare.backend.api.letter.dto.result.LetterFromDTO;
+import com.deare.backend.api.letter.dto.result.LetterItemDTO;
+import com.deare.backend.api.letter.util.ExcerptUtil;
+import com.deare.backend.domain.letter.entity.Letter;
+
+public final class LetterItemMapper {
+
+    private static final int EXCERPT_MAX_CHARS = 100;
+
+    private LetterItemMapper() {
+    }
+
+    public static LetterItemDTO toItemDTO(Letter letter) {
+        return new LetterItemDTO(
+                letter.getId(),
+                ExcerptUtil.excerptByChars(letter.getContent(), EXCERPT_MAX_CHARS),
+                letter.isLiked(),
+                letter.getReceivedAt(),
+                letter.getCreatedAt(),
+                new LetterFromDTO(
+                        letter.getFrom().getId(),
+                        letter.getFrom().getName(),
+                        letter.getFrom().getBackgroundColor(),
+                        letter.getFrom().getFontColor()
+                ),
+                letter.getFolder() != null ? letter.getFolder().getId() : null
+        );
+    }
+}

--- a/src/main/java/com/deare/backend/api/letter/service/LetterServiceImpl.java
+++ b/src/main/java/com/deare/backend/api/letter/service/LetterServiceImpl.java
@@ -8,8 +8,8 @@ import com.deare.backend.api.letter.dto.request.LetterPinRequestDTO;
 import com.deare.backend.api.letter.dto.request.LetterReplyUpsertRequestDTO;
 import com.deare.backend.api.letter.dto.request.LetterUpdateRequestDTO;
 import com.deare.backend.api.letter.dto.response.*;
+import com.deare.backend.api.letter.mapper.LetterItemMapper;
 import com.deare.backend.api.letter.dto.result.*;
-import com.deare.backend.api.letter.util.ExcerptUtil;
 import com.deare.backend.domain.emotion.entity.Emotion;
 import com.deare.backend.domain.emotion.entity.LetterEmotion;
 import com.deare.backend.domain.emotion.repository.EmotionRepository;
@@ -47,8 +47,6 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class LetterServiceImpl implements LetterService {
 
-    private static final int EXCERPT_MAX_CHARS = 100;
-
     private final LetterRepository letterRepository;
     private final LetterEmotionQueryRepository letterEmotionQueryRepository;
     private final FromRepository fromRepository;
@@ -80,7 +78,7 @@ public class LetterServiceImpl implements LetterService {
         );
 
         List<LetterItemDTO> items = page.getContent().stream()
-                .map(this::toItemDTO)
+                .map(LetterItemMapper::toItemDTO)
                 .toList();
 
         return new LetterListResponseDTO(
@@ -342,23 +340,6 @@ public class LetterServiceImpl implements LetterService {
         }
 
         return letter;
-    }
-
-    private LetterItemDTO toItemDTO(Letter letter) {
-        return new LetterItemDTO(
-                letter.getId(),
-                ExcerptUtil.excerptByChars(letter.getContent(), EXCERPT_MAX_CHARS),
-                letter.isLiked(),
-                letter.getReceivedAt(),
-                letter.getCreatedAt(),
-                new LetterFromDTO(
-                        letter.getFrom().getId(),
-                        letter.getFrom().getName(),
-                        letter.getFrom().getBackgroundColor(),
-                        letter.getFrom().getFontColor()
-                ),
-                letter.getFolder() != null ? letter.getFolder().getId() : null
-        );
     }
 
     @Override

--- a/src/main/java/com/deare/backend/domain/letter/repository/LetterRepositoryCustom.java
+++ b/src/main/java/com/deare/backend/domain/letter/repository/LetterRepositoryCustom.java
@@ -17,6 +17,15 @@ public interface LetterRepositoryCustom {
             Pageable pageable
     );
 
+    Page<Letter> findAvailableLetters(
+            Long userId,
+            Long excludedFolderId,
+            Long fromId,
+            Boolean isLiked,
+            String keyword,
+            Pageable pageable
+    );
+
     Optional<Letter> findLetterDetailById(Long userId, Long letterId);
 
     Optional<Letter> findRandomLetterByUser(Long userId, long offset, LocalDateTime createdBefore);

--- a/src/main/java/com/deare/backend/domain/letter/repository/LetterRepositoryImpl.java
+++ b/src/main/java/com/deare/backend/domain/letter/repository/LetterRepositoryImpl.java
@@ -88,6 +88,60 @@ public class LetterRepositoryImpl implements LetterRepositoryCustom {
     }
 
     @Override
+    public Page<Letter> findAvailableLetters(
+            Long userId,
+            Long excludedFolderId,
+            Long fromId,
+            Boolean isLiked,
+            String keyword,
+            Pageable pageable
+    ) {
+        QLetter letter = QLetter.letter;
+        QFrom from = QFrom.from;
+        QFolder folder = QFolder.folder;
+
+        JPAQuery<Letter> contentQuery = queryFactory
+                .selectFrom(letter)
+                .join(letter.from, from).fetchJoin()
+                .leftJoin(letter.folder, folder).fetchJoin()
+                .where(
+                        letter.isDeleted.isFalse(),
+                        ownedBy(letter, userId),
+                        letter.folder.isNull().or(letter.folder.id.ne(excludedFolderId)),
+                        fromIdEq(letter, fromId),
+                        isLikedEq(letter, isLiked),
+                        keywordLike(letter, keyword)
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+        List<OrderSpecifier<?>> orderSpecifiers = toOrderSpecifiers(pageable.getSort(), letter);
+        if (orderSpecifiers.isEmpty()) {
+            contentQuery.orderBy(letter.id.desc());
+        } else {
+            contentQuery.orderBy(orderSpecifiers.toArray(OrderSpecifier[]::new));
+        }
+
+        List<Letter> contents = contentQuery.fetch();
+        JPAQuery<Long> countQuery = queryFactory
+                .select(letter.count())
+                .from(letter)
+                .where(
+                        letter.isDeleted.isFalse(),
+                        ownedBy(letter, userId),
+                        letter.folder.isNull().or(letter.folder.id.ne(excludedFolderId)),
+                        fromIdEq(letter, fromId),
+                        isLikedEq(letter, isLiked),
+                        keywordLike(letter, keyword)
+                );
+
+        return PageableExecutionUtils.getPage(contents, pageable, () -> {
+            Long count = countQuery.fetchOne();
+            return count == null ? 0L : count;
+        });
+    }
+
+    @Override
     public Optional<Letter> findLetterDetailById(Long userId, Long letterId) {
         QLetter letter = QLetter.letter;
         QFrom from = QFrom.from;

--- a/src/main/java/com/deare/backend/global/common/response/ApiResponse.java
+++ b/src/main/java/com/deare/backend/global/common/response/ApiResponse.java
@@ -32,6 +32,15 @@ public class ApiResponse<T> {
                 .build();
     }
 
+    public static <T> ApiResponse<T> success(String code, String message, T data) {
+        return ApiResponse.<T>builder()
+                .success(true)
+                .code(code)
+                .message(message)
+                .data(data)
+                .build();
+    }
+
     public static <T> ApiResponse<T> fail(String code, String message) {
         return ApiResponse.<T>builder()
                 .success(false)

--- a/src/main/java/com/deare/backend/global/common/response/ApiResponse.java
+++ b/src/main/java/com/deare/backend/global/common/response/ApiResponse.java
@@ -32,15 +32,6 @@ public class ApiResponse<T> {
                 .build();
     }
 
-    public static <T> ApiResponse<T> success(String code, String message, T data) {
-        return ApiResponse.<T>builder()
-                .success(true)
-                .code(code)
-                .message(message)
-                .data(data)
-                .build();
-    }
-
     public static <T> ApiResponse<T> fail(String code, String message) {
         return ApiResponse.<T>builder()
                 .success(false)


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 요약 -->

- 폴더에 여러 편지를 일괄 추가/이동하는 API 구현
- 현재 폴더에 포함되지 않은 추가 가능 편지 목록을 조회하는 API 구현

---

## 🔗 관련 이슈
<!-- 관련 이슈 번호 -->

- Closes #228
- Closes #285

---

## 🛠 변경 사항
<!-- 핵심 변경 내용 -->

- POST /folders/{folderId}/letters 구현
  - 중복 편지 ID 제거 후 일괄 이동
  - 편지 중 하나라도 없거나 사용자 소유가 아니면 전체 요청 실패
- GET /folders/{folderId}/letters/available 구현
  - 현재 폴더에 포함된 편지를 제외하고 미소속/다른 폴더의 편지 조회
  - From, 좋아요, 키워드, 페이징 및 정렬 조건 적용
- 성공 응답 코드를 OK로 통일

---

## ⚠️ 리뷰 시 참고 사항
<!-- 리뷰어가 봐줬으면 하는 부분 -->

- 일괄 이동 전 편지 전체를 검증하는 흐름이 적절한지
- 추가 가능 편지 조회 조건이 적절한지

---

## ✅ 체크리스트
- [x] 로컬에서 정상 실행됨
- [x] 로그 / 네이밍 정리
- [x] main / develop 직접 커밋 아님


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 여러 편지를 한 번에 폴더에 추가할 수 있습니다.
  * 폴더에 아직 추가되지 않은 편지를 목록으로 확인할 수 있습니다.
  * 발신자, 좋아요 여부, 키워드로 편지를 필터링하고 페이지 단위로 조회할 수 있습니다.
  * 편지 추가 처리 결과와 미리보기 정보를 확인할 수 있습니다.

* **개선**
  * 중복 편지와 유효하지 않은 편지를 자동으로 검증합니다.
  * 편지 미리보기는 최대 100자까지 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->